### PR TITLE
0309_More Fix 

### DIFF
--- a/screens/Feed/ModifiyFeed.tsx
+++ b/screens/Feed/ModifiyFeed.tsx
@@ -25,7 +25,12 @@ import { useNavigation } from "@react-navigation/native";
 import CustomTextInput from "../../components/CustomTextInput";
 import CustomText from "../../components/CustomText";
 import { Modalize, useModalize } from "react-native-modalize";
-import { MaterialIcons, Ionicons, Entypo } from "@expo/vector-icons";
+import {
+  MaterialIcons,
+  Ionicons,
+  Entypo,
+  MaterialCommunityIcons
+} from "@expo/vector-icons";
 import Carousel from "../../components/Carousel";
 import FastImage from "react-native-fast-image";
 import { Portal } from "react-native-portalize";
@@ -61,7 +66,7 @@ const UserId = styled(CustomText)`
   bottom: 1px;
 `;
 
-const ClubBox = styled.View`
+const ClubBox = styled.TouchableOpacity`
   flex-direction: row;
   align-items: center;
   background-color: #c4c4c4;
@@ -91,10 +96,6 @@ const Ment = styled(CustomTextInput)`
   font-size: 14px;
 `;
 
-const ModalArea = styled.View`
-  flex: 1;
-`;
-
 //모달
 const ClubArea = styled.TouchableOpacity`
   flex-direction: row;
@@ -118,6 +119,7 @@ const HeaderNameView = styled.View`
   align-items: flex-start;
   padding-left: 4px;
 `;
+
 const ModalClubName = styled.Text`
   padding-left: 1%;
   color: black;
@@ -160,19 +162,24 @@ const ClubCtrgList = styled(CustomText)`
 
 const ModalContainer = styled.View`
   flex: 1;
-  top: 2%;
 `;
+
+const ModalContainText = styled.View`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+`
 
 const IntroTextLeft = styled(CustomText)`
   text-align: left;
   padding-left: 20px;
-  font-size: 10px;
+  font-size: 12px;
   color: #b0b0b0;
 `;
 
 const IntroTextRight = styled(CustomText)`
   text-align: right;
-  font-size: 10px;
+  font-size: 12px;
   padding-right: 20px;
   color: #b0b0b0;
 `;
@@ -181,7 +188,7 @@ const ModalView = styled.View`
   background-color: white;
   opacity: 1;
   width: 100%;
-  padding: 10px 20px 20px 20px;
+  padding: 10px 20px 10px 20px;
   height: auto;
 `;
 
@@ -282,26 +289,27 @@ const ModifiyFeed: React.FC<ModifiyFeedScreenProps> = ({
             <UserInfo>
               <UserId>{feedData.userName}</UserId>
               <View style={{ display: "flex", flexDirection: "row" }}>
-                <ClubBox>
+                <ClubBox onPress={onOpen}>
                   <ClubName>{clubName}</ClubName>
                 </ClubBox>
                 <TouchableOpacity onPress={onOpen}>
-                  <Ionicons name="pencil" size={18} style={{ top: 1 }} color="gray" />
+                  <MaterialCommunityIcons name="pencil-outline" size={20} style={{ top: 1 }} color="gray" />
                 </TouchableOpacity>
               </View>
             </UserInfo>
           </FeedUser>
           <Portal>
             <Modalize ref={modalizeRef} modalHeight={300}
-                      handleStyle={{ top: 14, height: 3, width: 35, backgroundColor: "#d4d4d4" }}
+                      handleStyle={{ top: 14, height: 3, width: 35, backgroundColor: "#d4d4d4"}}
                       handlePosition="inside"
-                      modalStyle={{ borderTopLeftRadius: 0, borderTopRightRadius: 0 }}>
+                      modalStyle={{ borderTopLeftRadius: 0, borderTopRightRadius: 0, paddingTop: 30}}
+            >
               <ModalContainer>
-                <View style={{ display: "flex", flexDirection: "row", justifyContent: "space-between" }}>
+                <ModalView>
+                  <ModalContainText>
                   <IntroTextLeft>모임 변경</IntroTextLeft>
                   <IntroTextRight>가입한 모임 List</IntroTextRight>
-                </View>
-                <ModalView>
+                </ModalContainText>
                     <FlatList
                         refreshing={refreshing}
                         keyExtractor={(item: MyClub, index: number) => String(index)}

--- a/screens/FeedCreation/ImageSelecter.tsx
+++ b/screens/FeedCreation/ImageSelecter.tsx
@@ -3,7 +3,12 @@ import React, {
   useEffect,
   useState
 } from "react";
-import { AntDesign, Entypo, MaterialIcons } from "@expo/vector-icons";
+import {
+  AntDesign,
+  Entypo,
+  Ionicons,
+  MaterialIcons, Octicons
+} from "@expo/vector-icons";
 import ImagePicker from "react-native-image-crop-picker";
 import {
   ActivityIndicator,
@@ -138,13 +143,13 @@ const ImageSelecter = (props: FeedCreateScreenProps) => {
   const toast = useToast();
   const [imageURL, setImageURL] = useState<string[]>([]);
   const [selectIndex, setSelectIndex] = useState<number>();
-  const [alert, alertSet] = useState(true);
   const [isSubmitShow, setSubmitShow] = useState(true);
 
   const { width: SCREEN_WIDTH } = useWindowDimensions();
-  const imageHeight = Math.floor(((SCREEN_WIDTH * 0.8) / 16) * 9);
   const [content, setContent] = useState("");
   const navigation = useNavigation();
+
+  const [buttonClicked, setButtonClicked] = useState(false);
 
   useEffect(() => {
     pickImage();
@@ -243,6 +248,7 @@ const ImageSelecter = (props: FeedCreateScreenProps) => {
       Alert.alert("글을 작성하세요");
     } else {
       setSubmitShow(false);
+      setButtonClicked(true);
       const data = {
         clubId: clubId,
         content: content.trim(),
@@ -289,11 +295,12 @@ const ImageSelecter = (props: FeedCreateScreenProps) => {
     navigation.setOptions({
       headerLeft: () => (
           <TouchableOpacity onPress={cancelCreate}>
-            <Entypo name="cross" size={20} color="black" />
+            <Octicons name="x" size={24} style={{top: 5}} color="black" />
           </TouchableOpacity>
       ),
       headerRight: () => (
           <TouchableOpacity
+            disabled={buttonClicked}
               onPress={() => {
                 onSubmit();
               }}
@@ -371,9 +378,11 @@ const ImageSelecter = (props: FeedCreateScreenProps) => {
               </MyImage>
               <ImageUnderArea>
                 <MoveImageText>사진을 옮겨 순서를 변경할 수 있습니다.</MoveImageText>
-                <TouchableOpacity onPress={morePickImage}>
-                  <MaterialIcons name="add-photo-alternate" size={23} color="black" />
-                </TouchableOpacity>
+                {imageURL.length <5 ? (
+                  <TouchableOpacity onPress={morePickImage}>
+                    <MaterialIcons name="add-photo-alternate" size={23} color="black" />
+                  </TouchableOpacity>
+                ):null}
               </ImageUnderArea>
             </SelectImageView>
             <FeedText

--- a/screens/FeedCreation/MyClubSelector.tsx
+++ b/screens/FeedCreation/MyClubSelector.tsx
@@ -25,7 +25,7 @@ const IntroText = styled(CustomText)`
 
 const ReplyContainer = styled.View`
   height: 100%;
-  padding-bottom: 60px;
+  padding-bottom: 40px;
 `;
 
 const ClubArea = styled.TouchableOpacity`


### PR DESCRIPTION
1. - 피드추가 하는 UI/UX 변경
원래 있던 아이콘버튼 삭제
5개 다 차면 + 사라지고 엑스로 지워서 5개 미만이면 + 생기고
2.[피드수정] 모임 변경 아이콘 바꾸기: 모임 내 수정페이지에서 썼던 연필 아이콘으로 통일
3.[피드수정] 모임 변경, 가입한 모임리스트 텍스트 확대:  +2px
4.[피드수정] 모임 리스트 변경하는 모달창에서 상단 중앙 바 아래로 10px 여백 주기
그 아래에 모임 변경, 가입한 모임 리스트, 모임 프로필 뜨도록. 스크롤 해도 확보한 상단 21px 영역(바 상단 10 + 바 1 + 바 하단 10px) 은 확보
5.[피드생성] 저장 누르고나면 로딩아이콘 생기는데 로딩 아이콘도 터치가 가능해서 여러번 누르면 피드 여러개 생김
6.피드 업로드 시 나의 모임 리스트가 짤리는 현상 수정 필요