### PR TITLE
Fix visioning to code push

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -149,8 +149,8 @@ android {
         applicationId "com.onyoufrontend"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 23043001
-        versionName "1.2.1"
+        versionCode 23050101
+        versionName "1.2.0"
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
         vectorDrawables.useSupportLibrary = true
         resValue 'string', "CODE_PUSH_APK_BUILD_TIME", String.format("\"%d\"", System.currentTimeMillis())

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "OnYou",
     "slug": "OnYou",
-    "version": "1.2.1",
+    "version": "1.0.0",
     "assetBundlePatterns": ["**/*"],
     "ios": {
       "bundleIdentifier": "y"

--- a/ios/onyoufrontend.xcodeproj/project.pbxproj
+++ b/ios/onyoufrontend.xcodeproj/project.pbxproj
@@ -364,7 +364,7 @@
 				CODE_SIGN_ENTITLEMENTS = onyoufrontend/onyoufrontend.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 23043002;
+				CURRENT_PROJECT_VERSION = 23050101;
 				DEVELOPMENT_TEAM = P83ZS7XR97;
 				ENABLE_BITCODE = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -376,7 +376,7 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.social-networking";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.2.0;
 				MODULE_VERSION = 1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -403,14 +403,14 @@
 				CODE_SIGN_ENTITLEMENTS = onyoufrontend/onyoufrontend.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 23043002;
+				CURRENT_PROJECT_VERSION = 23050101;
 				DEVELOPMENT_TEAM = P83ZS7XR97;
 				INFOPLIST_FILE = onyoufrontend/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = OnYou;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.social-networking";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.2.0;
 				MODULE_VERSION = 1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -605,14 +605,14 @@
 				CODE_SIGN_ENTITLEMENTS = onyoufrontend/onyoufrontend.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 23043002;
+				CURRENT_PROJECT_VERSION = 23050101;
 				DEVELOPMENT_TEAM = P83ZS7XR97;
 				INFOPLIST_FILE = onyoufrontend/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = OnYou;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.social-networking";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.2.0;
 				MODULE_VERSION = 1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",

--- a/navigation/Root.tsx
+++ b/navigation/Root.tsx
@@ -25,6 +25,8 @@ import queryString from "query-string";
 import { getModel, getVersion } from "react-native-device-info";
 import styled from "styled-components/native";
 import CustomText from "../components/CustomText";
+import CodePush from "react-native-code-push";
+import packageInfo from "../package.json";
 
 const Nav = createNativeStackNavigator();
 
@@ -112,6 +114,8 @@ const Root = () => {
   const updateMetaInfo = async () => {
     let deviceInfo = await getModel();
     let currentVersion = await getVersion();
+    let codePushInfo = await CodePush.getUpdateMetadata();
+    if (currentVersion && codePushInfo) currentVersion = currentVersion.slice(0, -1) + packageInfo.version.split(".")[2];
     const requestData: MetaInfoRequest = { deviceInfo, currentVersion };
 
     updateMetaInfoMutation.mutate(requestData, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onyoufrontend",
-  "version": "1.2.1",
+  "version": "1.0.1",
   "main": "index.js",
   "scripts": {
     "start": "expo start --dev-client",


### PR DESCRIPTION
1. Versioning Rule 정리
1.2.4 => (Major.Minier.Featrue)
Major와 Miner는 앱 심사 후 마켓에 업데이트될 때 증가
Feature 버전은 코드푸시로만 증가하고, package.json의 version 정보에서 가져온다.

ex)
마켓 버전 : 2.1.0
Package.json 버전: 1.0.7

이 떄 코드 푸시 후 버전 : 2.1.7
