### PR TITLE
Fix data overlapping issue in the club redux and some screens are changed design

### DIFF
--- a/App.js
+++ b/App.js
@@ -178,13 +178,13 @@ function App() {
         <Provider store={store}>
           <ToastProvider
             offset={70}
-            successColor="#295AF5"
-            warningColor="#6F6F6F"
-            dangerColor="#E7564F"
+            successColor={lightTheme.primaryColor}
+            warningColor={lightTheme.errorColor}
+            dangerColor={lightTheme.accentColor}
             duration={3000}
             animationType="zoom-in"
             style={{ borderRadius: 20, paddingHorizontal: 20, paddingVertical: 8 }}
-            textStyle={{ fontFamily: "AppleSDGothicNeoR", lineHeight: 16 }}
+            textStyle={{ fontFamily: lightTheme.koreanFontR, lineHeight: 16 }}
             successIcon={<Ionicons name="checkmark-circle" size={16} color="white" />}
             warningIcon={<Ionicons name="close-circle" size={16} color="white" />}
             dangerIcon={<Ionicons name="alert-circle" size={16} color="white" />}

--- a/api.ts
+++ b/api.ts
@@ -133,6 +133,7 @@ export interface LikeUser {
   thumbnail: string;
   userName: string;
   likeDate: string;
+  userId: number;
 }
 
 export interface Feed {

--- a/components/CircleIcon.tsx
+++ b/components/CircleIcon.tsx
@@ -3,6 +3,7 @@ import { MaterialIcons } from "@expo/vector-icons";
 import styled from "styled-components/native";
 import CustomText from "./CustomText";
 import FastImage from "react-native-fast-image";
+import { lightTheme } from "../theme";
 
 const Container = styled.TouchableOpacity<{ size: number; kerning: number; opacity: number }>`
   position: relative;
@@ -60,7 +61,7 @@ const CircleIcon: React.FC<CircleIconProps> = ({ size, uri, name, badge, kerning
     <Container size={size} kerning={kerning ?? 0} opacity={opacity ?? 1} activeOpacity={1} onPress={onPress}>
       {badge ? (
         <BadgeIcon size={size}>
-          <MaterialIcons name={badge} size={size * 0.4} color="#EC5D56" />
+          <MaterialIcons name={badge} size={size * 0.4} color={lightTheme.accentColor} />
         </BadgeIcon>
       ) : (
         <></>

--- a/components/ClubHeader.tsx
+++ b/components/ClubHeader.tsx
@@ -1,13 +1,52 @@
 import React from "react";
-import { View } from "react-native";
-import { MaterialIcons } from "@expo/vector-icons";
+import { TouchableOpacity, View } from "react-native";
+import { Entypo, Ionicons, MaterialIcons } from "@expo/vector-icons";
 import styled from "styled-components/native";
 import { Animated } from "react-native";
 import { BlurView } from "expo-blur";
 import FastImage from "react-native-fast-image";
-import { Club } from "../api";
+import { Club, ClubRole } from "../api";
 import CircleIcon from "./CircleIcon";
 import Tag from "./Tag";
+import { useNavigation } from "@react-navigation/native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+const NavigationView = styled.SafeAreaView<{ height: number }>`
+  position: absolute;
+  z-index: 3;
+  width: 100%;
+  height: ${(props: any) => props.height}px;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const LeftNavigationView = styled.View`
+  flex-direction: row;
+  padding-left: 16px;
+`;
+const RightNavigationView = styled.View`
+  flex-direction: row;
+  padding-right: 16px;
+`;
+
+const NotiView = styled.View``;
+const NotiBadge = styled.View`
+  position: absolute;
+  top: 0px;
+  right: -4px;
+  width: 5px;
+  height: 5px;
+  border-radius: 5px;
+  z-index: 1;
+  background-color: #ff6534;
+  justify-content: center;
+  align-items: center;
+`;
+const NotiBadgeText = styled.Text`
+  color: white;
+  font-size: 6px;
+`;
 
 const Header = styled.View`
   width: 100%;
@@ -19,7 +58,7 @@ const Header = styled.View`
 const FilterView = styled.View`
   flex: 1;
   width: 100%;
-  background-color: rgba(0, 0, 0, 0.6);
+  background-color: rgba(0, 0, 0, 0.5);
   padding-top: 70px;
   justify-content: center;
   align-items: center;
@@ -96,20 +135,37 @@ const CollapsedView = styled.SafeAreaView<{ height: number }>`
   height: ${(props) => props.height}px;
 `;
 
+const CollapsedNameView = styled.View`
+  align-items: center;
+`;
+
+const CollapsedNameText = styled.Text`
+  font-family: ${(props: any) => props.theme.koreanFontB};
+  font-size: 18px;
+  line-height: 22px;
+  color: #2b2b2b;
+`;
+
 const AnimatedBlurView = Animated.createAnimatedComponent(BlurView);
 const AnimatedFadeOutBox = Animated.createAnimatedComponent(View);
 
 // ClubHome Header
 export interface ClubHomeHaederProps {
   clubData: Club;
+  clubRole?: ClubRole;
+  notiCount: number;
+  openClubOptionModal: () => void;
+  headerHeight: number;
   heightExpanded: number;
   heightCollapsed: number;
   scrollY: Animated.Value;
   headerDiff: number;
 }
 
-const ClubHeader: React.FC<ClubHomeHaederProps> = ({ clubData, heightExpanded, heightCollapsed, headerDiff, scrollY }) => {
+const ClubHeader: React.FC<ClubHomeHaederProps> = ({ clubData, clubRole, notiCount, openClubOptionModal, headerHeight, heightExpanded, heightCollapsed, headerDiff, scrollY }) => {
+  const navigation = useNavigation();
   const master = clubData.members?.find((member) => member.role === "MASTER");
+  const { top } = useSafeAreaInsets();
   const fadeIn = scrollY.interpolate({
     inputRange: [0, headerDiff],
     outputRange: [-1, 1],
@@ -119,76 +175,122 @@ const ClubHeader: React.FC<ClubHomeHaederProps> = ({ clubData, heightExpanded, h
     inputRange: [0, headerDiff / 2, headerDiff],
     outputRange: [1, 0, 0],
   });
-  return (
-    <Header>
-      <FastImage style={{ width: "100%", height: heightExpanded }} source={clubData.thumbnail ? { uri: clubData.thumbnail } : require("../assets/basic.jpg")}>
-        <AnimatedBlurView
-          intensity={70}
-          tint="dark"
-          style={{
-            position: "absolute",
-            width: "100%",
-            zIndex: 2,
-            height: heightExpanded,
-            opacity: fadeIn,
-            justifyContent: "flex-start",
-          }}
-        >
-          <CollapsedView height={heightCollapsed}>
-            <ClubNameView>
-              <ClubNameText>{clubData.name}</ClubNameText>
-            </ClubNameView>
-            <ClubShortDescView>
-              <ClubShortDescText>{clubData.clubShortDesc}</ClubShortDescText>
-            </ClubShortDescView>
-          </CollapsedView>
-        </AnimatedBlurView>
 
-        <FilterView>
-          <AnimatedFadeOutBox style={{ opacity: fadeOut, width: "75%" }}>
-            <InformationView>
-              <CategoryView>
-                {clubData.categories?.map((category, index) => (
-                  <Tag key={`category_${index}`} name={category.name} backgroundColor={"rgba(255, 255, 255, 0.5)"} textColor={"black"} textStyle={{ fontSize: 12, lineHeight: 14 }} />
-                ))}
-              </CategoryView>
-              <ClubNameView>
-                <ClubNameText>{clubData.name}</ClubNameText>
-              </ClubNameView>
-              <ClubShortDescView>
-                <ClubShortDescText>{clubData.clubShortDesc}</ClubShortDescText>
-              </ClubShortDescView>
-              <Break />
-              <DetailInfoView>
-                <DetailInfoItem>
-                  <MaterialIcons name="star" size={16} color="#FADF7D" style={{ marginRight: 2 }} />
-                  <DetailItemTitle>{`리더`}</DetailItemTitle>
-                  {master ? (
-                    <>
-                      <CircleIcon size={18} uri={master.thumbnail} kerning={3} />
-                      <DetailItemText>{master.name}</DetailItemText>
-                    </>
-                  ) : (
-                    <DetailItemText>{`없음`}</DetailItemText>
-                  )}
-                </DetailInfoItem>
-                <DetailInfoItem>
-                  <MaterialIcons name="people" size={16} color="#FADF7D" style={{ marginRight: 2 }} />
-                  <DetailItemTitle>{`멤버`}</DetailItemTitle>
-                  <DetailItemText>{clubData.recruitNumber}</DetailItemText>
-                  <DetailItemText style={{ color: "#C0C0C0" }}>{` / ${clubData.maxNumber ? `${clubData.maxNumber} 명` : `무제한`}`}</DetailItemText>
-                </DetailInfoItem>
-                <DetailInfoItem>
-                  <MaterialIcons name="description" size={14} color="#FADF7D" style={{ marginRight: 2 }} />
-                  <DetailItemTitle>{`피드`}</DetailItemTitle>
-                  <DetailItemText>{clubData.feedNumber}</DetailItemText>
-                </DetailInfoItem>
-              </DetailInfoView>
-            </InformationView>
-          </AnimatedFadeOutBox>
-        </FilterView>
-      </FastImage>
-    </Header>
+  const goClubNotification = () => {
+    const clubNotificationProps = {
+      clubData,
+      clubRole,
+    };
+    navigation.navigate("ClubNotification", clubNotificationProps);
+  };
+
+  return (
+    <>
+      <NavigationView height={headerHeight} style={{ marginTop: top }}>
+        <LeftNavigationView>
+          <TouchableOpacity onPress={() => navigation.goBack()}>
+            <Animated.View style={{ position: "absolute" }}>
+              <Entypo name="chevron-thin-left" size={20} color="white" />
+            </Animated.View>
+            <Animated.View style={{ opacity: fadeIn }}>
+              <Entypo name="chevron-thin-left" size={20} color="black" />
+            </Animated.View>
+          </TouchableOpacity>
+        </LeftNavigationView>
+        <RightNavigationView>
+          {["MASTER", "MANAGER", "MEMBER"].includes(clubRole?.role) ? (
+            <TouchableOpacity onPress={goClubNotification} style={{ paddingHorizontal: 8 }}>
+              <Animated.View style={{ position: "absolute", left: 8 }}>
+                <NotiView>
+                  {notiCount > 0 ? <NotiBadge>{/* <NotiBadgeText>{notiCount}</NotiBadgeText> */}</NotiBadge> : <></>}
+                  <Ionicons name="mail-outline" size={22} color="white" />
+                </NotiView>
+              </Animated.View>
+              <Animated.View style={{ opacity: fadeIn }}>
+                <NotiView>
+                  {notiCount > 0 ? <NotiBadge>{/* <NotiBadgeText>{notiCount}</NotiBadgeText> */}</NotiBadge> : <></>}
+                  <Ionicons name="mail-outline" size={22} color="black" />
+                </NotiView>
+              </Animated.View>
+            </TouchableOpacity>
+          ) : null}
+          <TouchableOpacity onPress={openClubOptionModal} style={{ paddingLeft: 10, paddingRight: 1 }}>
+            <Animated.View style={{ position: "absolute", left: 10 }}>
+              <Ionicons name="ellipsis-vertical-sharp" size={22} color="white" />
+            </Animated.View>
+            <Animated.View style={{ opacity: fadeIn }}>
+              <Ionicons name="ellipsis-vertical-sharp" size={22} color="black" />
+            </Animated.View>
+          </TouchableOpacity>
+        </RightNavigationView>
+      </NavigationView>
+      <Header>
+        <FastImage style={{ width: "100%", height: heightExpanded }} source={clubData.thumbnail ? { uri: clubData.thumbnail } : require("../assets/basic.jpg")}>
+          <Animated.View
+            pointerEvents="box-none"
+            style={{
+              position: "absolute",
+              width: "100%",
+              zIndex: 2,
+              height: heightExpanded,
+              opacity: fadeIn,
+              justifyContent: "flex-start",
+              backgroundColor: "white",
+            }}
+          >
+            <CollapsedView height={headerHeight} style={{ marginTop: top }}>
+              <CollapsedNameView>
+                <CollapsedNameText>{clubData?.name}</CollapsedNameText>
+              </CollapsedNameView>
+            </CollapsedView>
+          </Animated.View>
+
+          <FilterView>
+            <AnimatedFadeOutBox style={{ opacity: fadeOut, width: "75%" }}>
+              <InformationView>
+                <CategoryView>
+                  {clubData.categories?.map((category, index) => (
+                    <Tag key={`category_${index}`} name={category.name} backgroundColor={"rgba(255, 255, 255, 0.5)"} textColor={"black"} textStyle={{ fontSize: 12, lineHeight: 14 }} />
+                  ))}
+                </CategoryView>
+                <ClubNameView>
+                  <ClubNameText>{clubData.name}</ClubNameText>
+                </ClubNameView>
+                <ClubShortDescView>
+                  <ClubShortDescText>{clubData.clubShortDesc}</ClubShortDescText>
+                </ClubShortDescView>
+                <Break />
+                <DetailInfoView>
+                  <DetailInfoItem>
+                    <MaterialIcons name="star" size={16} color="#FADF7D" style={{ marginRight: 2 }} />
+                    <DetailItemTitle>{`리더`}</DetailItemTitle>
+                    {master ? (
+                      <>
+                        <CircleIcon size={18} uri={master.thumbnail} kerning={3} />
+                        <DetailItemText>{master.name}</DetailItemText>
+                      </>
+                    ) : (
+                      <DetailItemText>{`없음`}</DetailItemText>
+                    )}
+                  </DetailInfoItem>
+                  <DetailInfoItem>
+                    <MaterialIcons name="people" size={16} color="#FADF7D" style={{ marginRight: 2 }} />
+                    <DetailItemTitle>{`멤버`}</DetailItemTitle>
+                    <DetailItemText>{clubData.recruitNumber}</DetailItemText>
+                    <DetailItemText style={{ color: "#C0C0C0" }}>{` / ${clubData.maxNumber ? `${clubData.maxNumber} 명` : `무제한`}`}</DetailItemText>
+                  </DetailInfoItem>
+                  <DetailInfoItem>
+                    <MaterialIcons name="description" size={14} color="#FADF7D" style={{ marginRight: 2 }} />
+                    <DetailItemTitle>{`피드`}</DetailItemTitle>
+                    <DetailItemText>{clubData.feedNumber}</DetailItemText>
+                  </DetailInfoItem>
+                </DetailInfoView>
+              </InformationView>
+            </AnimatedFadeOutBox>
+          </FilterView>
+        </FastImage>
+      </Header>
+    </>
   );
 };
 

--- a/components/ClubHeader.tsx
+++ b/components/ClubHeader.tsx
@@ -40,7 +40,7 @@ const NotiBadge = styled.View`
   height: 5px;
   border-radius: 5px;
   z-index: 1;
-  background-color: #ff6534;
+  background-color: ${(props: any) => props.theme.accentColor};
   justify-content: center;
   align-items: center;
 `;

--- a/components/ClubHeader.tsx
+++ b/components/ClubHeader.tsx
@@ -10,6 +10,7 @@ import CircleIcon from "./CircleIcon";
 import Tag from "./Tag";
 import { useNavigation } from "@react-navigation/native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { lightTheme } from "../theme";
 
 const NavigationView = styled.SafeAreaView<{ height: number }>`
   position: absolute;
@@ -262,7 +263,7 @@ const ClubHeader: React.FC<ClubHomeHaederProps> = ({ clubData, clubRole, notiCou
                 <Break />
                 <DetailInfoView>
                   <DetailInfoItem>
-                    <MaterialIcons name="star" size={16} color="#FADF7D" style={{ marginRight: 2 }} />
+                    <MaterialIcons name="star" size={16} color={lightTheme.secondaryColor} style={{ marginRight: 2 }} />
                     <DetailItemTitle>{`리더`}</DetailItemTitle>
                     {master ? (
                       <>
@@ -274,13 +275,13 @@ const ClubHeader: React.FC<ClubHomeHaederProps> = ({ clubData, clubRole, notiCou
                     )}
                   </DetailInfoItem>
                   <DetailInfoItem>
-                    <MaterialIcons name="people" size={16} color="#FADF7D" style={{ marginRight: 2 }} />
+                    <MaterialIcons name="people" size={16} color={lightTheme.secondaryColor} style={{ marginRight: 2 }} />
                     <DetailItemTitle>{`멤버`}</DetailItemTitle>
                     <DetailItemText>{clubData.recruitNumber}</DetailItemText>
                     <DetailItemText style={{ color: "#C0C0C0" }}>{` / ${clubData.maxNumber ? `${clubData.maxNumber} 명` : `무제한`}`}</DetailItemText>
                   </DetailInfoItem>
                   <DetailInfoItem>
-                    <MaterialIcons name="description" size={14} color="#FADF7D" style={{ marginRight: 2 }} />
+                    <MaterialIcons name="description" size={14} color={lightTheme.secondaryColor} style={{ marginRight: 2 }} />
                     <DetailItemTitle>{`피드`}</DetailItemTitle>
                     <DetailItemText>{clubData.feedNumber}</DetailItemText>
                   </DetailInfoItem>

--- a/components/ClubList.tsx
+++ b/components/ClubList.tsx
@@ -27,7 +27,7 @@ const Gradient = styled(LinearGradient)<{ size: number }>`
 `;
 
 const RecruitView = styled.View`
-  background-color: #ff6534;
+  background-color: ${(props: any) => props.theme.accentColor};
   padding: 1.5px 5px;
   border-radius: 3px;
   margin-bottom: 3px;

--- a/components/CommentDetail.tsx
+++ b/components/CommentDetail.tsx
@@ -8,6 +8,7 @@ import { TouchableOpacity } from "react-native-gesture-handler";
 import styled from "styled-components/native";
 import { FeedComment } from "../api";
 import CircleIcon from "./CircleIcon";
+import { lightTheme } from "../theme";
 
 const Container = styled.View`
   flex-direction: row;
@@ -105,7 +106,7 @@ const CommentDetail: React.FC<CommentDetailProps> = ({ commentData, commentType,
       </View>
       <Side width={sideWidth}>
         <LikeButton onPress={() => likeComment(commentData.commentId, commentType, parentIndex, replyIndex)}>
-          {commentData.likeYn ? <Ionicons name="heart" size={20} color="#EC5D56" /> : <Ionicons name="heart-outline" size={20} color="#BABABA" />}
+          {commentData.likeYn ? <Ionicons name="heart" size={20} color={lightTheme.accentColor} /> : <Ionicons name="heart-outline" size={20} color="#BABABA" />}
         </LikeButton>
       </Side>
     </Container>

--- a/components/CommentDetail.tsx
+++ b/components/CommentDetail.tsx
@@ -1,7 +1,10 @@
 import { Ionicons } from "@expo/vector-icons";
+import { useNavigation } from "@react-navigation/native";
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import moment from "moment";
 import React from "react";
 import { useWindowDimensions, View } from "react-native";
+import { TouchableOpacity } from "react-native-gesture-handler";
 import styled from "styled-components/native";
 import { FeedComment } from "../api";
 import CircleIcon from "./CircleIcon";
@@ -70,6 +73,7 @@ interface CommentDetailProps {
 }
 
 const CommentDetail: React.FC<CommentDetailProps> = ({ commentData, commentType, parentIndex, replyIndex, parentId, thumbnailSize, thumbnailKerning, likeComment, setReplyStatus }) => {
+  const navigation = useNavigation<NativeStackNavigationProp<any>>();
   const { width: SCREEN_WIDTH } = useWindowDimensions();
   const paddingSize = 20;
   const sideWidth = 20;
@@ -77,12 +81,16 @@ const CommentDetail: React.FC<CommentDetailProps> = ({ commentData, commentType,
   const replyPaddingLeft = paddingSize + thumbnailSize + thumbnailKerning;
   const replyContentWidth = contentWidth - thumbnailSize - thumbnailKerning;
 
+  const goToProfile = (userId: number) => navigation.push("ProfileStack", { screen: "Profile", params: { userId } });
+
   return (
     <Container style={{ paddingVertical: 10, paddingLeft: commentType === 1 ? replyPaddingLeft : paddingSize, paddingRight: paddingSize }}>
-      <CircleIcon uri={commentData.thumbnail} size={thumbnailSize} kerning={thumbnailKerning} />
+      <CircleIcon uri={commentData.thumbnail} size={thumbnailSize} kerning={thumbnailKerning} onPress={() => goToProfile(commentData.userId)} />
       <View>
         <Header>
-          <UserName>{commentData.userName.trim()}</UserName>
+          <TouchableOpacity activeOpacity={1} onPress={() => goToProfile(commentData.userId)}>
+            <UserName>{commentData.userName.trim()}</UserName>
+          </TouchableOpacity>
           <SubText>{moment(commentData.created, "YYYY-MM-DDThh:mm:ss").fromNow()}</SubText>
         </Header>
         <Content width={commentType === 1 ? replyContentWidth : contentWidth}>

--- a/components/FeedDetail.tsx
+++ b/components/FeedDetail.tsx
@@ -17,6 +17,7 @@ import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { useSelector } from "react-redux";
 import { RootState } from "../redux/store/reducers";
+import { lightTheme } from "../theme";
 
 const Container = styled.View``;
 const HeaderView = styled.View<{ padding: number; height: number }>`
@@ -329,7 +330,7 @@ const FeedDetail: React.FC<FeedDetailProps> = ({ feedData, feedIndex, feedSize, 
           autoPlay={false}
           loop={false}
           speed={1.0}
-          colorFilters={[{ keypath: "Filled", color: "#EC5D56" }]}
+          colorFilters={[{ keypath: "Filled", color: lightTheme.accentColor }]}
           onAnimationFinish={onBgHeartAnimationFinish}
           autoSize={true}
           style={{ width: 200, height: 200 }}
@@ -347,7 +348,7 @@ const FeedDetail: React.FC<FeedDetailProps> = ({ feedData, feedIndex, feedSize, 
                   loop={false}
                   speed={1.5}
                   colorFilters={[
-                    { keypath: "Filled", color: "#EC5D56" },
+                    { keypath: "Filled", color: lightTheme.accentColor },
                     { keypath: "Empty", color: "#000000" },
                   ]}
                   style={{ width: 35, height: 35, marginLeft: -2 }}

--- a/components/FeedDetail.tsx
+++ b/components/FeedDetail.tsx
@@ -15,6 +15,8 @@ import { CameraRoll } from "@react-native-camera-roll/camera-roll";
 import Lottie from "lottie-react-native";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { useSelector } from "react-redux";
+import { RootState } from "../redux/store/reducers";
 
 const Container = styled.View``;
 const HeaderView = styled.View<{ padding: number; height: number }>`
@@ -87,7 +89,7 @@ const CreatedTime = styled.Text`
   font-family: ${(props: any) => props.theme.koreanFontR};
   font-size: 12px;
 `;
-const ContentTextView = styled.Text<{ height: number }>`
+const ContentTextView = styled.Text<{ height?: number }>`
   ${(props: any) => (props.height ? `height: ${props.height}px` : "")};
 `;
 const ContentText = styled.Text`
@@ -137,6 +139,7 @@ interface FeedDetailState {
 }
 
 const FeedDetail: React.FC<FeedDetailProps> = ({ feedData, feedIndex, feedSize, headerHeight, infoHeight, contentHeight, showClubName, isMyClubPost, goToFeedOptionModal, likeFeed }) => {
+  const me = useSelector((state: RootState) => state.auth.user);
   let lastTapTime: number | undefined = undefined;
   const heartRef = useRef<Lottie>(null);
   const bgHeartRef = useRef<Lottie>(null);
@@ -181,7 +184,9 @@ const FeedDetail: React.FC<FeedDetailProps> = ({ feedData, feedIndex, feedSize, 
   }, [feedData?.likeYn]);
 
   const onPressHeart = () => {
-    if (likeFeed) likeFeed(feedIndex, feedData?.id);
+    if (likeFeed) {
+      likeFeed(feedIndex, feedData?.id);
+    }
   };
 
   const doubleTap = () => {
@@ -199,7 +204,9 @@ const FeedDetail: React.FC<FeedDetailProps> = ({ feedData, feedIndex, feedSize, 
         heartRef.current?.play(10, 25);
         bgHeartRef.current?.play(10, 25);
       } else {
-        if (likeFeed) likeFeed(feedIndex, feedData?.id);
+        if (likeFeed) {
+          likeFeed(feedIndex, feedData?.id);
+        }
       }
     } else {
       lastTapTime = now;
@@ -217,10 +224,19 @@ const FeedDetail: React.FC<FeedDetailProps> = ({ feedData, feedIndex, feedSize, 
     navigation.push("FeedStack", { screen: "FeedComments", params: { feedIndex, feedId } });
   }, []);
 
-  const goToFeedLikes = useCallback((likeUsers?: LikeUser[]) => {
-    if (!likeUsers || likeUsers.length === 0) return;
-    navigation.push("FeedStack", { screen: "FeedLikes", params: { likeUsers } });
-  }, []);
+  const goToFeedLikes = useCallback(
+    (likeUsers?: LikeUser[]) => {
+      // 로그인 되어있다면, likeYn에 따라 likeUsers 목록에 내 정보를 넣거나 뺀다.
+      if (me?.thumbnail && me?.name && me?.id) {
+        likeUsers = likeUsers?.filter((user) => user.userId != me?.id);
+        if (feedData?.likeYn) likeUsers?.push({ thumbnail: me?.thumbnail, userName: me?.name, likeDate: moment().tz("Asia/Seoul").format("YYYY-MM-DDThh:mm:ss"), userId: me?.id });
+      }
+
+      if (!likeUsers || likeUsers.length === 0) return;
+      navigation.push("FeedStack", { screen: "FeedLikes", params: { likeUsers } });
+    },
+    [feedData?.likeYn]
+  );
 
   const onBgHeartAnimationFinish = () => {
     Animated.timing(opacity, {
@@ -278,9 +294,7 @@ const FeedDetail: React.FC<FeedDetailProps> = ({ feedData, feedIndex, feedSize, 
                 <TouchableOpacity activeOpacity={1} onPress={() => goToClub(feedData?.clubId)}>
                   <Tag name={feedData?.clubName ?? ""} contentContainerStyle={{ paddingLeft: 7, paddingRight: 7 }} textColor="#464646" backgroundColor="#E6E6E6" />
                 </TouchableOpacity>
-              ) : (
-                <></>
-              )}
+              ) : null}
             </HeaderNameView>
             <CreatedTime>{moment(feedData?.created, "YYYY-MM-DDThh:mm:ss").fromNow()}</CreatedTime>
           </HeaderInformationView>
@@ -314,7 +328,7 @@ const FeedDetail: React.FC<FeedDetailProps> = ({ feedData, feedIndex, feedSize, 
           source={require("../assets/lottie/like-background.json")}
           autoPlay={false}
           loop={false}
-          speed={1.5}
+          speed={1.0}
           colorFilters={[{ keypath: "Filled", color: "#EC5D56" }]}
           onAnimationFinish={onBgHeartAnimationFinish}
           autoSize={true}

--- a/components/FloatingActionButton.tsx
+++ b/components/FloatingActionButton.tsx
@@ -4,6 +4,7 @@ import { MaterialIcons } from "@expo/vector-icons";
 import { Platform, View } from "react-native";
 import { ClubRole } from "../api";
 import Lottie from "lottie-react-native";
+import { lightTheme } from "../theme";
 
 const Container = styled.View`
   position: absolute;
@@ -78,10 +79,10 @@ const FloatingActionButton: React.FC<ClubHomeFloatingButtonProps> = ({ role, rec
         {isJoined ? (
           <>
             <IconButton>
-              <MaterialIcons name={"star"} size={28} color="#EC5D56" />
+              <MaterialIcons name={"star"} size={28} color={lightTheme.accentColor} />
             </IconButton>
             <IconButton>
-              <MaterialIcons name="chat" size={28} color="#EC5D56" />
+              <MaterialIcons name="chat" size={28} color={lightTheme.accentColor} />
             </IconButton>
           </>
         ) : (
@@ -94,14 +95,14 @@ const FloatingActionButton: React.FC<ClubHomeFloatingButtonProps> = ({ role, rec
                 loop={false}
                 speed={1.5}
                 colorFilters={[
-                  { keypath: "Filled", color: "#EC5D56" },
+                  { keypath: "Filled", color: lightTheme.accentColor },
                   { keypath: "Empty", color: "#E0E0E0" },
                 ]}
                 style={{ width: 38, height: 38 }}
               />
             </LottieButton>
             <IconButton onPress={openShare}>
-              <MaterialIcons name="ios-share" size={25} color="#6B8BF7" />
+              <MaterialIcons name="ios-share" size={25} color={lightTheme.primaryColor} />
             </IconButton>
           </>
         )}

--- a/components/FloatingActionButton.tsx
+++ b/components/FloatingActionButton.tsx
@@ -6,7 +6,7 @@ import { ClubRole } from "../api";
 import Lottie from "lottie-react-native";
 import { lightTheme } from "../theme";
 
-const Container = styled.View`
+const Container = styled.View<{ height: number }>`
   position: absolute;
   flex-direction: row;
   background-color: white;
@@ -14,7 +14,7 @@ const Container = styled.View`
   justify-content: space-between;
   z-index: 2;
   width: 100%;
-  height: 70px;
+  height: ${(props: any) => props.height}px;
   bottom: 0px;
   padding-right: 20px;
   padding-left: 20px;
@@ -50,6 +50,7 @@ const ButtonText = styled.Text`
 `;
 
 export interface ClubHomeFloatingButtonProps {
+  height: number;
   role?: ClubRole | null;
   recruitStatus?: "OPEN" | "CLOSE" | null;
   openShare: () => void;
@@ -57,7 +58,7 @@ export interface ClubHomeFloatingButtonProps {
   goToFeedCreation: () => void;
 }
 
-const FloatingActionButton: React.FC<ClubHomeFloatingButtonProps> = ({ role, recruitStatus, openShare, goToClubJoin, goToFeedCreation }) => {
+const FloatingActionButton: React.FC<ClubHomeFloatingButtonProps> = ({ height, role, recruitStatus, openShare, goToClubJoin, goToFeedCreation }) => {
   const [like, setLike] = useState<boolean>(false);
   const heartRef = useRef<Lottie>(null);
   const isJoined = role?.applyStatus === "APPROVED" ? true : false;
@@ -74,7 +75,7 @@ const FloatingActionButton: React.FC<ClubHomeFloatingButtonProps> = ({ role, rec
   };
 
   return (
-    <Container>
+    <Container height={height}>
       <SectionLeft>
         {isJoined ? (
           <>

--- a/components/ProfileHeader.tsx
+++ b/components/ProfileHeader.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { TouchableOpacity } from "react-native";
+import { Platform, StatusBar, TouchableOpacity } from "react-native";
 import styled from "styled-components/native";
 import { Animated } from "react-native";
 import FastImage from "react-native-fast-image";
@@ -196,7 +196,7 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
               backgroundColor: "white",
             }}
           >
-            <CollapsedView height={heightCollapsed}>
+            <CollapsedView height={headerHeight} style={{ marginTop: top }}>
               <CollapsedNameView>
                 <CollapsedNameText>{profile?.name ?? "이름"}</CollapsedNameText>
               </CollapsedNameView>

--- a/components/ProfileHeader.tsx
+++ b/components/ProfileHeader.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Platform, StatusBar, TouchableOpacity } from "react-native";
+import { TouchableOpacity } from "react-native";
 import styled from "styled-components/native";
 import { Animated } from "react-native";
 import FastImage from "react-native-fast-image";
@@ -37,7 +37,7 @@ const Header = styled.View`
 const FilterView = styled.View`
   flex: 1;
   width: 100%;
-  background-color: rgba(0, 0, 0, 0.6);
+  background-color: rgba(0, 0, 0, 0.5);
   align-items: center;
 `;
 const InfoView = styled.View`

--- a/components/TabBar.tsx
+++ b/components/TabBar.tsx
@@ -14,13 +14,13 @@ const TabBarContainer = styled.View<{ height: number; rounding: boolean }>`
   border-top-right-radius: ${(props: any) => (props.rounding ? 80 : 0)}px;
 `;
 
-const TabButton = styled.TouchableOpacity<{ isFocused: boolean; height: number }>`
+const TabButton = styled.TouchableOpacity<{ isFocused: boolean; height: number; focusColor?: string }>`
   flex: 1;
   height: ${(props: any) => props.height}px;
   justify-content: center;
   align-items: center;
   border-bottom-width: 2px;
-  border-bottom-color: ${(props: any) => (props.isFocused ? props.theme.primaryColor : "transparent")};
+  border-bottom-color: ${(props: any) => (props.isFocused ? props.focusColor ?? props.theme.primaryColor : "transparent")};
 `;
 
 const TextWrap = styled.View<{ height: number }>`
@@ -38,9 +38,10 @@ const TabText = styled.Text<{ isFocused: boolean }>`
 interface TabBarProps extends MaterialTopTabBarProps {
   height: number;
   rounding?: boolean;
+  focusColor?: string;
 }
 
-const TabBar: React.FC<TabBarProps> = ({ state, descriptors, navigation, height, rounding }) => {
+const TabBar: React.FC<TabBarProps> = ({ state, descriptors, navigation, height, rounding, focusColor }) => {
   return (
     <TabBarContainer height={height} rounding={rounding ?? false}>
       {state.routes.map((route, index) => {
@@ -71,6 +72,7 @@ const TabBar: React.FC<TabBarProps> = ({ state, descriptors, navigation, height,
             onPress={onPress}
             height={height}
             isFocused={isFocused}
+            focusColor={focusColor}
           >
             <TextWrap height={height}>
               <TabText isFocused={isFocused}>{label}</TabText>

--- a/navigation/ClubCreationStack.tsx
+++ b/navigation/ClubCreationStack.tsx
@@ -8,6 +8,7 @@ import ClubCreationStepThree from "../screens/ClubCreation/ClubCreationStepThree
 import { ClubCreationStackProps, ClubStackParamList } from "../Types/Club";
 import ClubCreationSuccess from "../screens/ClubCreation/ClubCreationSuccess";
 import ClubCreationFail from "../screens/ClubCreation/ClubCreationFail";
+import { lightTheme } from "../theme";
 
 const NativeStack = createNativeStackNavigator<ClubStackParamList>();
 
@@ -18,7 +19,7 @@ const ClubCreationStack: React.FC<ClubCreationStackProps> = ({ navigation: { nav
         presentation: "card",
         contentStyle: { backgroundColor: "white" },
         headerTitleAlign: "center",
-        headerTitleStyle: { fontFamily: "AppleSDGothicNeoB", fontSize: 16 },
+        headerTitleStyle: { fontFamily: lightTheme.koreanFontB, fontSize: 16 },
         headerShadowVisible: false,
       }}
     >

--- a/navigation/ClubCreationStack.tsx
+++ b/navigation/ClubCreationStack.tsx
@@ -18,7 +18,8 @@ const ClubCreationStack: React.FC<ClubCreationStackProps> = ({ navigation: { nav
         presentation: "card",
         contentStyle: { backgroundColor: "white" },
         headerTitleAlign: "center",
-        headerTitleStyle: { fontFamily: "NotoSansKR-Medium", fontSize: 16 },
+        headerTitleStyle: { fontFamily: "AppleSDGothicNeoB", fontSize: 16 },
+        headerShadowVisible: false,
       }}
     >
       <NativeStack.Screen name="ClubCreationStepOne" component={ClubCreationStepOne} options={{ title: "모임 개설" }} />

--- a/navigation/ClubManagementStack.tsx
+++ b/navigation/ClubManagementStack.tsx
@@ -23,7 +23,8 @@ const ClubManagementStack: React.FC<ClubManagementStackProps> = ({
         presentation: "card",
         contentStyle: { backgroundColor: "white" },
         headerTitleAlign: "center",
-        headerTitleStyle: { fontFamily: "NotoSansKR-Medium", fontSize: 16 },
+        headerTitleStyle: { fontFamily: "AppleSDGothicNeoB", fontSize: 16 },
+        headerShadowVisible: false,
       }}
     >
       <NativeStack.Screen name="ClubManagementMain" component={ClubManagementMain} options={{ headerShown: false }} />

--- a/navigation/ClubManagementStack.tsx
+++ b/navigation/ClubManagementStack.tsx
@@ -8,6 +8,7 @@ import ClubEditIntroduction from "../screens/ClubManagement/ClubEditIntroduction
 import ClubEditMembers from "../screens/ClubManagement/ClubEditMembers";
 import ClubDelete from "../screens/ClubManagement/ClubDelete";
 import { TouchableOpacity } from "react-native";
+import { lightTheme } from "../theme";
 
 const NativeStack = createNativeStackNavigator<ClubStackParamList>();
 
@@ -23,7 +24,7 @@ const ClubManagementStack: React.FC<ClubManagementStackProps> = ({
         presentation: "card",
         contentStyle: { backgroundColor: "white" },
         headerTitleAlign: "center",
-        headerTitleStyle: { fontFamily: "AppleSDGothicNeoB", fontSize: 16 },
+        headerTitleStyle: { fontFamily: lightTheme.koreanFontB, fontSize: 16 },
         headerShadowVisible: false,
       }}
     >

--- a/navigation/ClubStack.tsx
+++ b/navigation/ClubStack.tsx
@@ -10,6 +10,7 @@ import ClubFeedDetail from "../screens/Club/ClubFeedDetail";
 import ClubJoinReject from "../screens/Club/ClubJoinReject";
 import ClubJoinRejectMessage from "../screens/Club/ClubJoinRejectMessage";
 import ClubInvitation from "../screens/Club/ClubInvitation";
+import { lightTheme } from "../theme";
 
 const NativeStack = createNativeStackNavigator();
 
@@ -20,7 +21,7 @@ const ClubStack = ({ route: { params }, navigation: { navigate, goBack } }) => {
         presentation: "card",
         contentStyle: { backgroundColor: "white" },
         headerTitleAlign: "center",
-        headerTitleStyle: { fontFamily: "AppleSDGothicNeoB", fontSize: 16 },
+        headerTitleStyle: { fontFamily: lightTheme.koreanFontB, fontSize: 16 },
         headerShadowVisible: false,
       }}
     >

--- a/navigation/ClubStack.tsx
+++ b/navigation/ClubStack.tsx
@@ -20,7 +20,8 @@ const ClubStack = ({ route: { params }, navigation: { navigate, goBack } }) => {
         presentation: "card",
         contentStyle: { backgroundColor: "white" },
         headerTitleAlign: "center",
-        headerTitleStyle: { fontFamily: "NotoSansKR-Medium", fontSize: 16 },
+        headerTitleStyle: { fontFamily: "AppleSDGothicNeoB", fontSize: 16 },
+        headerShadowVisible: false,
       }}
     >
       <NativeStack.Screen name="ClubTopTabs" component={ClubTopTabs} options={{ headerShown: false }} />

--- a/navigation/FeedStack.tsx
+++ b/navigation/FeedStack.tsx
@@ -16,7 +16,8 @@ const FeedStack = ({ route: { params }, navigation: { navigate } }) => {
         presentation: "card",
         contentStyle: { backgroundColor: "white" },
         headerTitleAlign: "center",
-        headerTitleStyle: { fontFamily: "NotoSansKR-Medium", fontSize: 16 },
+        headerTitleStyle: { fontFamily: "AppleSDGothicNeoB", fontSize: 16 },
+        headerShadowVisible: false,
       }}
     >
       <NativeStack.Screen name="FeedComments" component={FeedComments} options={{ title: "댓글" }} />

--- a/navigation/FeedStack.tsx
+++ b/navigation/FeedStack.tsx
@@ -6,6 +6,7 @@ import FeedModification from "../screens/Feed/FeedModification";
 import ClubSelection from "../screens/FeedCreation/ClubSelection";
 import FeedSelection from "../screens/Feed/FeedSelection";
 import FeedLikes from "../screens/Feed/FeedLikes";
+import { lightTheme } from "../theme";
 
 const NativeStack = createNativeStackNavigator();
 
@@ -16,7 +17,7 @@ const FeedStack = ({ route: { params }, navigation: { navigate } }) => {
         presentation: "card",
         contentStyle: { backgroundColor: "white" },
         headerTitleAlign: "center",
-        headerTitleStyle: { fontFamily: "AppleSDGothicNeoB", fontSize: 16 },
+        headerTitleStyle: { fontFamily: lightTheme.koreanFontB, fontSize: 16 },
         headerShadowVisible: false,
       }}
     >

--- a/navigation/LoginStack.tsx
+++ b/navigation/LoginStack.tsx
@@ -7,6 +7,7 @@ import { Entypo } from "@expo/vector-icons";
 import FindEmail from "../screens/Login/FindEmail";
 import FindPassword from "../screens/Login/FindPassword";
 import FindResult from "../screens/Login/FindResult";
+import { lightTheme } from "../theme";
 
 const NativeStack = createNativeStackNavigator();
 
@@ -22,7 +23,7 @@ const LoginStack = ({
         presentation: "card",
         contentStyle: { backgroundColor: "white" },
         headerTitleAlign: "center",
-        headerTitleStyle: { fontFamily: "AppleSDGothicNeoB", fontSize: 16 },
+        headerTitleStyle: { fontFamily: lightTheme.koreanFontB, fontSize: 16 },
         headerShadowVisible: false,
       }}
     >

--- a/navigation/LoginStack.tsx
+++ b/navigation/LoginStack.tsx
@@ -22,7 +22,7 @@ const LoginStack = ({
         presentation: "card",
         contentStyle: { backgroundColor: "white" },
         headerTitleAlign: "center",
-        headerTitleStyle: { fontFamily: "NotoSansKR-Medium", fontSize: 16 },
+        headerTitleStyle: { fontFamily: "AppleSDGothicNeoB", fontSize: 16 },
         headerShadowVisible: false,
       }}
     >

--- a/navigation/ProfileStack.tsx
+++ b/navigation/ProfileStack.tsx
@@ -13,6 +13,7 @@ import Notice from "../screens/Preferences/Others/Notice";
 import Info from "../screens/Preferences/Others/Info";
 import UserNotification from "../screens/Profile/UserNotification";
 import Preferences from "../screens/Preferences/Preferences";
+import { lightTheme } from "../theme";
 
 const NativeStack = createNativeStackNavigator();
 
@@ -24,7 +25,7 @@ const ProfileStack = ({ route: { params }, navigation: { navigate, goBack } }) =
         presentation: "card",
         headerTitleAlign: "center",
         contentStyle: { backgroundColor: "white" },
-        headerTitleStyle: { fontFamily: "AppleSDGothicNeoB", fontSize: 16 },
+        headerTitleStyle: { fontFamily: lightTheme.koreanFontB, fontSize: 16 },
         headerShadowVisible: false,
       }}
     >

--- a/navigation/ProfileStack.tsx
+++ b/navigation/ProfileStack.tsx
@@ -23,6 +23,7 @@ const ProfileStack = ({ route: { params }, navigation: { navigate, goBack } }) =
       screenOptions={{
         presentation: "card",
         headerTitleAlign: "center",
+        contentStyle: { backgroundColor: "white" },
         headerTitleStyle: { fontFamily: "AppleSDGothicNeoB", fontSize: 16 },
         headerShadowVisible: false,
       }}

--- a/navigation/ProfileStack.tsx
+++ b/navigation/ProfileStack.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import Profile from "../screens/Profile/Profile";
-import EditAccount from "../screens/Preferences/EditAccount";
+import AccountEdit from "../screens/Preferences/AccountEdit";
 import MyClubs from "../screens/Preferences/Activity/MyClubs";
 import AccountSetting from "../screens/Preferences/Settings/AccountSetting";
 import ChangePassword from "../screens/Preferences/Settings/ChangePassword";
@@ -29,7 +29,7 @@ const ProfileStack = ({ route: { params }, navigation: { navigate, goBack } }) =
     >
       <NativeStack.Screen name="Profile" component={Profile} initialParams={{}} options={{ headerShown: false }} />
       <NativeStack.Screen name="Preferences" component={Preferences} options={{ title: "설정" }} />
-      <NativeStack.Screen name="EditAccount" component={EditAccount} options={{ title: "프로필 수정" }} />
+      <NativeStack.Screen name="AccountEdit" component={AccountEdit} options={{ title: "프로필 수정" }} />
       <NativeStack.Screen name="MyClubs" component={MyClubs} options={{ title: "나의 모임" }} />
       <NativeStack.Screen name="AccountSetting" component={AccountSetting} options={{ title: "계정" }} />
       <NativeStack.Screen name="ChangePassword" component={ChangePassword} options={{ title: "비밀번호 변경" }} />

--- a/navigation/SignupStack.tsx
+++ b/navigation/SignupStack.tsx
@@ -12,6 +12,7 @@ import SignUpPhone from "../screens/SignUp/SignUpPhone";
 import SignUpChurch from "../screens/SignUp/SignUpChurch";
 import SignUpConfirm from "../screens/SignUp/SignUpConfirm";
 import SignUpSuccess from "../screens/SignUp/SignUpSuccess";
+import { lightTheme } from "../theme";
 
 const NativeStack = createNativeStackNavigator();
 
@@ -22,7 +23,7 @@ const SignUpStack = ({ navigation: { navigate, goBack }, route: { params } }) =>
         presentation: "card",
         contentStyle: { backgroundColor: "white" },
         headerTitleAlign: "center",
-        headerTitleStyle: { fontFamily: "AppleSDGothicNeoB", fontSize: 16 },
+        headerTitleStyle: { fontFamily: lightTheme.koreanFontB, fontSize: 16 },
         headerShadowVisible: false,
       }}
     >

--- a/navigation/SignupStack.tsx
+++ b/navigation/SignupStack.tsx
@@ -22,7 +22,7 @@ const SignUpStack = ({ navigation: { navigate, goBack }, route: { params } }) =>
         presentation: "card",
         contentStyle: { backgroundColor: "white" },
         headerTitleAlign: "center",
-        headerTitleStyle: { fontFamily: "NotoSansKR-Medium", fontSize: 16 },
+        headerTitleStyle: { fontFamily: "AppleSDGothicNeoB", fontSize: 16 },
         headerShadowVisible: false,
       }}
     >

--- a/redux/slices/club.ts
+++ b/redux/slices/club.ts
@@ -5,34 +5,22 @@ interface ClubState {
   feeds: Feed[];
   role?: "MASTER" | "MANAGER" | "MEMBER" | "PENDING" | null;
   applyStatus?: "APPLIED" | "APPROVED" | null;
-  homeScrollY: number;
-  scheduleScrollX: number;
 }
 
 const initialState: ClubState = {
   feeds: [],
   role: null,
   applyStatus: null,
-  homeScrollY: 0,
-  scheduleScrollX: 0,
 };
 
 const clubSlice = createSlice({
   name: "club",
   initialState,
   reducers: {
-    updateClubHomeScrollY(state, action) {
-      state.homeScrollY = action.payload.scrollY;
-    },
-    updateClubHomeScheduleScrollX(state, action) {
-      state.scheduleScrollX = action.payload.scrollX;
-    },
     deleteClub(state) {
       state.feeds = [];
       state.role = null;
       state.applyStatus = null;
-      state.homeScrollY = 0;
-      state.scheduleScrollX = 0;
     },
     refreshFeed(state, action) {
       state.feeds = [].concat(action.payload);

--- a/redux/slices/club.ts
+++ b/redux/slices/club.ts
@@ -1,46 +1,53 @@
 import { createSlice } from "@reduxjs/toolkit";
 import { ClubRole, Feed } from "../../api";
 
-interface ClubState {
+interface ClubData {
   feeds: Feed[];
   role?: "MASTER" | "MANAGER" | "MEMBER" | "PENDING" | null;
   applyStatus?: "APPLIED" | "APPROVED" | null;
 }
 
-const initialState: ClubState = {
-  feeds: [],
-  role: null,
-  applyStatus: null,
-};
+interface ClubState {
+  [index: number]: ClubData;
+}
+
+const initialState: ClubState = {};
 
 const clubSlice = createSlice({
   name: "club",
   initialState,
   reducers: {
-    deleteClub(state) {
-      state.feeds = [];
-      state.role = null;
-      state.applyStatus = null;
+    initClub(state, action) {
+      state[action.payload.clubId] = {
+        feeds: [],
+        role: null,
+        applyStatus: null,
+      };
+    },
+    deleteClub(state, action) {
+      delete state[action.payload.clubId];
     },
     refreshFeed(state, action) {
-      state.feeds = [].concat(action.payload);
+      state[action.payload.clubId].feeds = [...action.payload.feeds];
     },
     addFeed(state, action) {
-      state.feeds = state.feeds.concat(action.payload);
+      const { clubId, feeds } = action.payload;
+      state[clubId].feeds = [...state[clubId].feeds, ...feeds];
     },
     likeToggle(state, action) {
-      if (state.feeds[action.payload].likeYn) state.feeds[action.payload].likesCount--;
-      else state.feeds[action.payload].likesCount++;
-      state.feeds[action.payload].likeYn = !state.feeds[action.payload].likeYn;
+      const { clubId, feedIndex } = action.payload;
+      if (state[clubId].feeds[feedIndex].likeYn) state[clubId].feeds[feedIndex].likesCount--;
+      else state[clubId].feeds[feedIndex].likesCount++;
+      state[clubId].feeds[feedIndex].likeYn = !state[clubId].feeds[feedIndex].likeYn;
     },
     updateCommentCount(state, action) {
-      if (state.feeds.length > action.payload.feedIndex) {
-        state.feeds[action.payload.feedIndex].commentCount = action.payload.count;
-      }
+      const { clubId, feedIndex, count } = action.payload;
+      if (state[clubId].feeds.length > feedIndex) state[clubId].feeds[feedIndex].commentCount = count;
     },
     updateClubRole(state, action) {
-      state.role = action.payload.role;
-      state.applyStatus = action.payload.applyStatus;
+      const { clubId, role, applyStatus } = action.payload;
+      state[clubId].role = role;
+      state[clubId].applyStatus = applyStatus;
     },
   },
   // extraReducer는 비동기 액션 생성시 필요

--- a/screens/Auth/Main.tsx
+++ b/screens/Auth/Main.tsx
@@ -24,13 +24,13 @@ const ContentView = styled.View`
 `;
 
 const ContentText = styled.Text`
-  font-family: "AppleSDGothicNeoM";
+  font-family: ${(props: any) => props.theme.koreanFontM};
   font-size: 18px;
   margin-bottom: 10px;
 `;
 
 const ContentTitle = styled.Text`
-  font-family: "TT-Commons-Bold";
+  font-family: ${(props: any) => props.theme.englishSecondaryFontB};
   font-size: 40px;
 `;
 
@@ -55,7 +55,7 @@ const Button = styled.TouchableHighlight`
 `;
 
 const Title = styled.Text<{ color: string }>`
-  font-family: "AppleSDGothicNeoM";
+  font-family: ${(props: any) => props.theme.koreanFontM};
   color: ${(props: any) => props.color};
   font-size: 20px;
   line-height: 21px;

--- a/screens/Club/ClubFeed.tsx
+++ b/screens/Club/ClubFeed.tsx
@@ -61,8 +61,7 @@ const ClubFeed: React.FC<ClubFeedScreenProps & ClubFeedParamList> = ({
   syncScrollOffset,
   screenScrollRefs,
 }) => {
-  const feeds = useSelector((state: RootState) => state.club.feeds);
-  const myRole = useSelector((state: RootState) => state.club.role);
+  const feeds = useSelector((state: RootState) => state.club[clubData.id]?.feeds);
   const toast = useToast();
   const queryClient = useQueryClient();
   const dispatch = useAppDispatch();
@@ -84,7 +83,7 @@ const ClubFeed: React.FC<ClubFeedScreenProps & ClubFeedParamList> = ({
       }
     },
     onSuccess: (res) => {
-      if (res.pages[res.pages.length - 1].responses) dispatch(clubSlice.actions.addFeed(res.pages[res.pages.length - 1].responses.content));
+      if (res.pages[res.pages.length - 1].responses) dispatch(clubSlice.actions.addFeed({ clubId: clubData.id, feeds: res.pages[res.pages.length - 1].responses.content }));
       console.log("dispatch update!");
     },
     onError: (error) => {
@@ -100,7 +99,7 @@ const ClubFeed: React.FC<ClubFeedScreenProps & ClubFeedParamList> = ({
   const onRefresh = async () => {
     setRefreshing(true);
     const result = await feedsRefetch();
-    dispatch(clubSlice.actions.refreshFeed(result?.data?.pages?.map((page) => page?.responses?.content).flat() ?? []));
+    dispatch(clubSlice.actions.refreshFeed({ clubId: clubData.id, feeds: result?.data?.pages?.map((page) => page?.responses?.content).flat() ?? [] }));
     setRefreshing(false);
   };
 

--- a/screens/Club/ClubFeedDetail.tsx
+++ b/screens/Club/ClubFeedDetail.tsx
@@ -100,16 +100,6 @@ const ClubFeedDetail: React.FC<ClubFeedDetailScreenProps> = ({
     openComplainOption();
   };
 
-  const goToFeedComments = (feedIndex?: number, feedId?: number) => {
-    if (feedIndex === undefined || feedId === undefined) return;
-    navigate("FeedStack", { screen: "FeedComments", params: { feedIndex, feedId, clubId: clubData.id } });
-  };
-
-  const goToFeedLikes = (likeUsers?: LikeUser[]) => {
-    if (!likeUsers || likeUsers.length === 0) return;
-    navigate("FeedStack", { screen: "FeedLikes", params: { likeUsers } });
-  };
-
   const goToUpdateFeed = () => {
     closeFeedOption();
     navigate("FeedStack", { screen: "FeedModification", params: { feedData: selectFeedData } });
@@ -271,8 +261,6 @@ const ClubFeedDetail: React.FC<ClubFeedDetailScreenProps> = ({
         infoHeight={feedDetailInfoHeight}
         contentHeight={feedDetailContentHeight}
         goToFeedOptionModal={goToFeedOptionModal}
-        goToFeedComments={goToFeedComments}
-        goToFeedLikes={goToFeedLikes}
         likeFeed={likeFeed}
         isMyClubPost={["MASTER", "MANAGER", "MEMBER"].includes(myRole ?? "") ? true : false}
       />

--- a/screens/Club/ClubFeedDetail.tsx
+++ b/screens/Club/ClubFeedDetail.tsx
@@ -43,8 +43,8 @@ const ClubFeedDetail: React.FC<ClubFeedDetailScreenProps> = ({
   },
 }) => {
   const me = useSelector((state: RootState) => state.auth.user);
-  const myRole = useSelector((state: RootState) => state.club.role);
-  const feeds = useSelector((state: RootState) => state.club.feeds);
+  const myRole = useSelector((state: RootState) => state.club[clubData.id]?.role);
+  const feeds = useSelector((state: RootState) => state.club[clubData.id]?.feeds);
   const queryClient = useQueryClient();
   const dispatch = useAppDispatch();
   const toast = useToast();
@@ -150,7 +150,7 @@ const ClubFeedDetail: React.FC<ClubFeedDetailScreenProps> = ({
       },
     });
 
-    dispatch(clubSlice.actions.likeToggle(feedIndex));
+    dispatch(clubSlice.actions.likeToggle({ clubId: clubData.id, feedIndex }));
   }, []);
 
   const blockUser = () => {

--- a/screens/Club/ClubFeedDetail.tsx
+++ b/screens/Club/ClubFeedDetail.tsx
@@ -2,10 +2,10 @@ import React, { useCallback, useLayoutEffect, useState } from "react";
 import { Alert, DeviceEventEmitter, FlatList, Platform, StatusBar, TouchableOpacity, useWindowDimensions, View } from "react-native";
 import { useModalize } from "react-native-modalize";
 import { useToast } from "react-native-toast-notifications";
-import { useMutation } from "react-query";
+import { InfiniteData, useMutation, useQueryClient } from "react-query";
 import { useSelector } from "react-redux";
 import styled from "styled-components/native";
-import { BaseResponse, ErrorResponse, Feed, FeedApi, FeedDeletionRequest, FeedLikeRequest, FeedReportRequest, LikeUser, UserApi, UserBlockRequest } from "../../api";
+import { BaseResponse, ErrorResponse, Feed, FeedApi, FeedDeletionRequest, FeedLikeRequest, FeedReportRequest, FeedsResponse, LikeUser, UserApi, UserBlockRequest } from "../../api";
 import CustomText from "../../components/CustomText";
 import FeedDetail from "../../components/FeedDetail";
 import { ClubFeedDetailScreenProps } from "../../Types/Club";
@@ -39,12 +39,13 @@ const HeaderText = styled(CustomText)`
 const ClubFeedDetail: React.FC<ClubFeedDetailScreenProps> = ({
   navigation: { setOptions, navigate, goBack },
   route: {
-    params: { clubData, targetIndex },
+    params: { clubData, targetIndex, fetchNextPage },
   },
 }) => {
   const me = useSelector((state: RootState) => state.auth.user);
   const myRole = useSelector((state: RootState) => state.club.role);
   const feeds = useSelector((state: RootState) => state.club.feeds);
+  const queryClient = useQueryClient();
   const dispatch = useAppDispatch();
   const toast = useToast();
   const { ref: feedOptionRef, open: openFeedOption, close: closeFeedOption } = useModalize();
@@ -228,8 +229,8 @@ const ClubFeedDetail: React.FC<ClubFeedDetailScreenProps> = ({
   };
 
   const loadMore = () => {
-    console.log("ClubFeedDetail - Load more club feed!");
-    DeviceEventEmitter.emit("ClubFeedLoadmore");
+    const query = queryClient.getQueryData<InfiniteData<FeedsResponse>>(["getClubFeeds", clubData.id]);
+    if (query?.pages[query?.pages.length - 1].hasData) fetchNextPage();
   };
 
   useLayoutEffect(() => {

--- a/screens/Club/ClubHome.tsx
+++ b/screens/Club/ClubHome.tsx
@@ -1,22 +1,9 @@
-import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
-import {
-  ActivityIndicator,
-  useWindowDimensions,
-  Animated,
-  FlatList,
-  DeviceEventEmitter,
-  TouchableWithoutFeedback,
-  View,
-  Text,
-  KeyboardAvoidingView,
-  Platform,
-  LayoutChangeEvent,
-  Keyboard,
-} from "react-native";
+import React, { useEffect, useLayoutEffect, useState } from "react";
+import { ActivityIndicator, useWindowDimensions, Animated, FlatList, DeviceEventEmitter, TouchableWithoutFeedback, View } from "react-native";
 import styled from "styled-components/native";
 import { Feather, Ionicons } from "@expo/vector-icons";
-import { ClubHomeScreenProps, ClubHomeParamList, RefinedSchedule } from "../../Types/Club";
-import { BaseResponse, ClubApi, ErrorResponse, GuestComment, GuestCommentRequest, GuestCommentResponse, Member } from "../../api";
+import { ClubHomeScreenProps, RefinedSchedule } from "../../Types/Club";
+import { ClubApi, ErrorResponse, GuestComment, GuestCommentResponse, Member } from "../../api";
 import ScheduleModal from "./ClubScheduleModal";
 import CircleIcon from "../../components/CircleIcon";
 import CustomText from "../../components/CustomText";
@@ -26,10 +13,8 @@ import { useSelector } from "react-redux";
 import { RootState } from "../../redux/store/reducers";
 import { useToast } from "react-native-toast-notifications";
 import Collapsible from "react-native-collapsible";
-import { useMutation, useQuery } from "react-query";
+import { useQuery } from "react-query";
 import moment from "moment";
-import Carousel from "../../components/Carousel";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 const MEMBER_ICON_KERNING = 20;
 const MEMBER_ICON_SIZE = 40;
@@ -131,7 +116,7 @@ const ScheduleDetailItemView = styled.View`
   margin: 3px 5px;
 `;
 
-const ScheduleText = styled(CustomText)<{ index: number }>`
+const ScheduleText = styled(CustomText)<{ index?: number }>`
   font-size: 11px;
   line-height: 15px;
   color: ${(props: any) => (props.index === 0 ? "white" : "black")};
@@ -230,6 +215,17 @@ const EmptyText = styled.Text`
   text-align: center;
 `;
 
+// ClubHome Param For Collapsed Scroll Animation
+export interface ClubHomeParamList {
+  scrollY: Animated.Value;
+  headerDiff: number;
+  headerCollapsedHeight: number;
+  actionButtonHeight: number;
+  schedules?: RefinedSchedule[];
+  syncScrollOffset: (screenName: string) => void;
+  screenScrollRefs: any;
+}
+
 const ClubHome: React.FC<ClubHomeScreenProps & ClubHomeParamList> = ({
   navigation: { navigate, push },
   route: {
@@ -237,9 +233,9 @@ const ClubHome: React.FC<ClubHomeScreenProps & ClubHomeParamList> = ({
     params: { clubData },
   },
   scrollY,
-  offsetY,
-  scheduleOffsetX,
   headerDiff,
+  headerCollapsedHeight,
+  actionButtonHeight,
   schedules,
   syncScrollOffset,
   screenScrollRefs,
@@ -340,12 +336,9 @@ const ClubHome: React.FC<ClubHomeScreenProps & ClubHomeParamList> = ({
           screenScrollRefs.current[screenName] = ref;
         }}
         onScroll={Animated.event([{ nativeEvent: { contentOffset: { y: scrollY } } }], { useNativeDriver: true })}
-        onMomentumScrollEnd={(event) => {
-          dispatch(clubSlice.actions.updateClubHomeScrollY({ scrollY: event.nativeEvent.contentOffset.y }));
-          syncScrollOffset(screenName);
-        }}
+        onMomentumScrollEnd={(event) => syncScrollOffset(screenName)}
         onScrollEndDrag={() => syncScrollOffset(screenName)}
-        contentOffset={{ x: 0, y: offsetY ?? 0 }}
+        contentOffset={{ x: 0, y: 0 }}
         style={{
           flex: 1,
           paddingTop: 15,
@@ -363,7 +356,7 @@ const ClubHome: React.FC<ClubHomeScreenProps & ClubHomeParamList> = ({
         contentContainerStyle={{
           paddingTop: headerDiff,
           paddingBottom: headerDiff * 2,
-          minHeight: SCREEN_HEIGHT + headerDiff * 2,
+          minHeight: SCREEN_HEIGHT + headerCollapsedHeight,
           backgroundColor: "#F5F5F5",
         }}
       >
@@ -405,7 +398,7 @@ const ClubHome: React.FC<ClubHomeScreenProps & ClubHomeParamList> = ({
               horizontal
               showsHorizontalScrollIndicator={false}
               onMomentumScrollEnd={(event) => dispatch(clubSlice.actions.updateClubHomeScheduleScrollX({ scrollX: event.nativeEvent.contentOffset.x }))}
-              contentOffset={{ x: scheduleOffsetX ?? 0, y: 0 }}
+              contentOffset={{ x: 0, y: 0 }}
               contentContainerStyle={{ paddingVertical: 6, paddingHorizontal: SCREEN_PADDING_SIZE }}
               data={schedules}
               keyExtractor={(item: RefinedSchedule, index: number) => String(index)}

--- a/screens/Club/ClubHome.tsx
+++ b/screens/Club/ClubHome.tsx
@@ -247,7 +247,7 @@ const ClubHome: React.FC<ClubHomeScreenProps & ClubHomeParamList> = ({
   const [memberLoading, setMemberLoading] = useState(true);
   const [members, setMembers] = useState<Member[]>([]);
   const dispatch = useAppDispatch();
-  const myRole = useSelector((state: RootState) => state.club.role);
+  const myRole = useSelector((state: RootState) => state.club[clubData.id]?.role);
   const toast = useToast();
   const [clubLongDescLines, setClubLongDescLines] = useState<string[]>(typeof clubData?.clubLongDesc === "string" ? clubData?.clubLongDesc?.split("\n") : []);
   const [isCollapsedLongDesc, setIsCollapsedLongDesc] = useState<boolean>(true);
@@ -268,7 +268,6 @@ const ClubHome: React.FC<ClubHomeScreenProps & ClubHomeParamList> = ({
 
     return () => {
       guestCommentSubscription.remove();
-      dispatch(clubSlice.actions.deleteClub());
       console.log("ClubHome - remove listner");
     };
   }, []);

--- a/screens/Club/ClubHome.tsx
+++ b/screens/Club/ClubHome.tsx
@@ -231,7 +231,7 @@ const EmptyText = styled.Text`
 `;
 
 const ClubHome: React.FC<ClubHomeScreenProps & ClubHomeParamList> = ({
-  navigation: { navigate },
+  navigation: { navigate, push },
   route: {
     name: screenName,
     params: { clubData },
@@ -272,6 +272,8 @@ const ClubHome: React.FC<ClubHomeScreenProps & ClubHomeParamList> = ({
 
     return () => {
       guestCommentSubscription.remove();
+      dispatch(clubSlice.actions.deleteClub());
+      console.log("ClubHome - remove listner");
     };
   }, []);
 
@@ -320,7 +322,7 @@ const ClubHome: React.FC<ClubHomeScreenProps & ClubHomeParamList> = ({
     }
   };
 
-  const goToProfile = (userId: number) => navigate("ProfileStack", { screen: "Profile", params: { userId } });
+  const goToProfile = (userId: number) => push("ProfileStack", { screen: "Profile", params: { userId } });
 
   const clubLongDescTouch = () => {
     setIsCollapsedLongDesc((prev) => !prev);

--- a/screens/Club/ClubOptionModal.tsx
+++ b/screens/Club/ClubOptionModal.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Platform, StatusBar, View } from "react-native";
+import { View } from "react-native";
 import { Modalize } from "react-native-modalize";
 import { Portal } from "react-native-portalize";
 import styled from "styled-components/native";
@@ -64,18 +64,6 @@ const ClubOptionModal: React.FC<ClubOptionModalProps> = ({ modalRef, buttonHeigh
         handlePosition="inside"
         handleStyle={{ top: 14, height: 3, width: 35, backgroundColor: "#d4d4d4" }}
         modalStyle={{ borderTopLeftRadius: 0, borderTopRightRadius: 0 }}
-        onOpen={() => {
-          if (Platform.OS === "android") {
-            StatusBar.setBackgroundColor("black", true);
-            StatusBar.setBarStyle("light-content", true);
-          }
-        }}
-        onClose={() => {
-          if (Platform.OS === "android") {
-            StatusBar.setBackgroundColor("white", true);
-            StatusBar.setBarStyle("dark-content", true);
-          }
-        }}
       >
         <ModalContainer style={{ flex: 1 }}>
           {clubOptionList.map((option, index) => (

--- a/screens/Club/ClubScheduleModal.tsx
+++ b/screens/Club/ClubScheduleModal.tsx
@@ -109,7 +109,7 @@ const ApplyButton = styled.TouchableOpacity<{ participation: boolean }>`
   align-items: center;
   background-color: ${(props: any) => (props.participation ? "white" : "#FF6534")};
   padding: 9px 0px;
-  border: 1px solid #ff6534;
+  border: 1px solid ${(props: any) => props.theme.accentColor};
   border-radius: 20px;
 `;
 

--- a/screens/Club/ClubScheduleModal.tsx
+++ b/screens/Club/ClubScheduleModal.tsx
@@ -161,7 +161,7 @@ const ScheduleModal: React.FC<ScheduleModalProps> = ({ visible, clubId, schedule
   const toast = useToast();
   const navigation = useNavigation();
   const me = useSelector((state: RootState) => state.auth.user);
-  const myRole = useSelector((state: RootState) => state.club.role);
+  const myRole = useSelector((state: RootState) => state.club[clubId]?.role);
   const [showModal, setShowModal] = useState<boolean>(visible);
   const [showMember, setShowMember] = useState<boolean>(false);
   const [menuVisibleMap, setMenuVisibleMap] = useState(new Map(scheduleData?.slice(0, -1).map((schedule) => [schedule.id, false])));

--- a/screens/Club/ClubTopTabs.tsx
+++ b/screens/Club/ClubTopTabs.tsx
@@ -317,10 +317,14 @@ const ClubTopTabs = ({
 
   // Screen Scroll Sync
   const syncScrollOffset = (screenName: string) => {
-    screenScrollOffset.current[screenName] = scrollY._value;
+    screenScrollOffset.current[screenName] = scrollY._value; // 현재 탭의 y 값 저장.
+
+    // 다른 탭들의 scroll 위치 조절
     for (const [key, ref] of Object.entries(screenScrollRefs.current)) {
       if (key === screenName) continue;
       const offsetY = screenScrollOffset.current[key] ?? 0;
+
+      // 현재 탭의 y 값과 헤더가 접히는 정도를 기준으로 다른 탭들의 스크롤 위치를 변경한다.
       if (scrollY._value < headerDiff) {
         if (ref.scrollTo) {
           ref.scrollTo({

--- a/screens/Club/ClubTopTabs.tsx
+++ b/screens/Club/ClubTopTabs.tsx
@@ -167,7 +167,7 @@ const ClubTopTabs = ({
     refetch: clubRoleRefetch,
   } = useQuery<ClubRoleResponse, ErrorResponse>(["getClubRole", data.id], ClubApi.getClubRole, {
     onSuccess: (res) => {
-      dispatch(clubSlice.actions.updateClubRole({ role: res.data.role, applyStatus: res.data.applyStatus }));
+      dispatch(clubSlice.actions.updateClubRole({ clubId: data.id, role: res.data.role, applyStatus: res.data.applyStatus }));
     },
     onError: (error) => {
       console.log(`API ERROR | getClubRole ${error.code} ${error.status}`);
@@ -399,6 +399,8 @@ const ClubTopTabs = ({
   };
 
   useEffect(() => {
+    dispatch(clubSlice.actions.initClub({ clubId: data.id }));
+
     const scrollListener = scrollY.addListener(({ value }) => {});
 
     console.log("ClubTopTabs - add listner");
@@ -446,7 +448,7 @@ const ClubTopTabs = ({
       keyboardDidShowListener.remove();
       keyboardDidHideListener.remove();
       backHandler.remove();
-      dispatch(clubSlice.actions.deleteClub());
+      dispatch(clubSlice.actions.deleteClub({ clubId: data.id }));
       console.log("ClubTopTabs - remove listner & delete clubslice");
     };
   }, []);

--- a/screens/Club/ClubTopTabs.tsx
+++ b/screens/Club/ClubTopTabs.tsx
@@ -95,6 +95,7 @@ const TopTab = createMaterialTopTabNavigator();
 const HEADER_EXPANDED_HEIGHT = 300;
 const HEADER_HEIGHT = 56;
 const TAB_BUTTON_HEIGHT = 46;
+const ACTION_BUTTON_HEIGHT = 70;
 
 const AnimatedFooterView = Animated.createAnimatedComponent(FooterView);
 
@@ -224,8 +225,6 @@ const ClubTopTabs = ({
   const screenScrollRefs = useRef<any>({});
   const screenScrollOffset = useRef<any>({});
   const scrollY = useRef(new Animated.Value(0)).current;
-  const offsetY = useSelector((state: RootState) => state.club.homeScrollY);
-  const scheduleOffsetX = useSelector((state: RootState) => state.club.scheduleScrollX);
   const translateY = scrollY.interpolate({
     inputRange: [0, headerDiff],
     outputRange: [0, -headerDiff],
@@ -459,9 +458,9 @@ const ClubTopTabs = ({
         <ClubHome
           {...props}
           scrollY={scrollY}
-          offsetY={offsetY}
-          scheduleOffsetX={scheduleOffsetX}
           headerDiff={headerDiff}
+          headerCollapsedHeight={heightCollapsed}
+          actionButtonHeight={ACTION_BUTTON_HEIGHT}
           schedules={scheduleData}
           syncScrollOffset={syncScrollOffset}
           screenScrollRefs={screenScrollRefs}
@@ -473,7 +472,17 @@ const ClubTopTabs = ({
   const renderClubFeed = useCallback(
     (props: any) => {
       props.route.params.clubData = data;
-      return <ClubFeed {...props} offsetY={offsetY} scrollY={scrollY} headerDiff={headerDiff} syncScrollOffset={syncScrollOffset} screenScrollRefs={screenScrollRefs} />;
+      return (
+        <ClubFeed
+          {...props}
+          scrollY={scrollY}
+          headerDiff={headerDiff}
+          headerCollapsedHeight={heightCollapsed}
+          actionButtonHeight={ACTION_BUTTON_HEIGHT}
+          syncScrollOffset={syncScrollOffset}
+          screenScrollRefs={screenScrollRefs}
+        />
+      );
     },
     [headerDiff, data]
   );
@@ -570,7 +579,14 @@ const ClubTopTabs = ({
       {clubRoleLoading ? (
         <></>
       ) : (
-        <FloatingActionButton role={clubRole?.data} recruitStatus={data?.recruitStatus} openShare={openShare} goToClubJoin={goToClubJoin} goToFeedCreation={goToFeedCreation} />
+        <FloatingActionButton
+          height={ACTION_BUTTON_HEIGHT}
+          role={clubRole?.data}
+          recruitStatus={data?.recruitStatus}
+          openShare={openShare}
+          goToClubJoin={goToClubJoin}
+          goToFeedCreation={goToFeedCreation}
+        />
       )}
 
       <ClubOptionModal

--- a/screens/Club/ClubTopTabs.tsx
+++ b/screens/Club/ClubTopTabs.tsx
@@ -1,21 +1,6 @@
 import React, { useState, useRef, useCallback, useMemo, useEffect } from "react";
 import { createMaterialTopTabNavigator } from "@react-navigation/material-top-tabs";
-import {
-  ActivityIndicator,
-  Alert,
-  Animated,
-  BackHandler,
-  DeviceEventEmitter,
-  Keyboard,
-  KeyboardAvoidingView,
-  LayoutChangeEvent,
-  Platform,
-  StatusBar,
-  Text,
-  TouchableOpacity,
-  useWindowDimensions,
-} from "react-native";
-import { Entypo, Ionicons } from "@expo/vector-icons";
+import { ActivityIndicator, Alert, Animated, BackHandler, DeviceEventEmitter, Keyboard, KeyboardAvoidingView, LayoutChangeEvent, Platform, StatusBar, useWindowDimensions } from "react-native";
 import ClubHome from "../Club/ClubHome";
 import ClubFeed from "../Club/ClubFeed";
 import styled from "styled-components/native";
@@ -52,42 +37,6 @@ import TabBar from "../../components/TabBar";
 
 const Container = styled.View`
   flex: 1;
-`;
-
-const NavigationView = styled.SafeAreaView<{ height: number }>`
-  position: absolute;
-  z-index: 3;
-  width: 100%;
-  height: ${(props: any) => props.height}px;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  padding: 5px 16px;
-`;
-
-const LeftNavigationView = styled.View`
-  flex-direction: row;
-`;
-const RightNavigationView = styled.View`
-  flex-direction: row;
-`;
-
-const NotiView = styled.View``;
-const NotiBadge = styled.View`
-  position: absolute;
-  top: 0px;
-  right: -4px;
-  width: 5px;
-  height: 5px;
-  border-radius: 5px;
-  z-index: 1;
-  background-color: #ff6534;
-  justify-content: center;
-  align-items: center;
-`;
-const NotiBadgeText = styled.Text`
-  color: white;
-  font-size: 6px;
 `;
 
 const FooterView = styled.View`
@@ -143,8 +92,8 @@ const SubmitButtonText = styled.Text<{ disabled: boolean }>`
 
 const TopTab = createMaterialTopTabNavigator();
 
-const HEADER_EXPANDED_HEIGHT = 270;
-const HEADER_HEIGHT = 100;
+const HEADER_EXPANDED_HEIGHT = 300;
+const HEADER_HEIGHT = 56;
 const TAB_BUTTON_HEIGHT = 46;
 
 const AnimatedFooterView = Animated.createAnimatedComponent(FooterView);
@@ -383,14 +332,6 @@ const ClubTopTabs = ({
     navigate("FeedStack", { screen: "ImageSelection", params: { clubId: data.id } });
   };
 
-  const goClubNotification = () => {
-    const clubNotificationProps = {
-      clubData: data,
-      clubRole: clubRole?.data,
-    };
-    navigate("ClubNotification", clubNotificationProps);
-  };
-
   const openShare = async () => {
     closeClubOption();
     const link = await dynamicLinks().buildShortLink(
@@ -429,6 +370,10 @@ const ClubTopTabs = ({
 
   const goToReportClub = () => {
     closeClubOption();
+  };
+
+  const openClubOptionModal = () => {
+    openClubOption();
   };
 
   const withdrawClub = () => {
@@ -535,40 +480,27 @@ const ClubTopTabs = ({
 
   return (
     <Container>
-      <StatusBar backgroundColor={"black"} barStyle={"light-content"} />
-
-      <NavigationView height={HEADER_HEIGHT}>
-        <LeftNavigationView>
-          <TouchableOpacity onPress={() => popToTop()}>
-            <Entypo name="chevron-thin-left" size={18} color="white" />
-          </TouchableOpacity>
-        </LeftNavigationView>
-        <RightNavigationView>
-          {clubRole?.data?.role && clubRole.data.role !== "PENDING" ? (
-            <TouchableOpacity onPress={goClubNotification} style={{ paddingHorizontal: 8 }}>
-              <NotiView>
-                {notiCount > 0 && !notiLoading ? <NotiBadge>{/* <NotiBadgeText>{notiCount}</NotiBadgeText> */}</NotiBadge> : <></>}
-                <Ionicons name="mail-outline" size={22} color="white" />
-              </NotiView>
-            </TouchableOpacity>
-          ) : (
-            <></>
-          )}
-          <TouchableOpacity onPress={() => openClubOption()} style={{ paddingLeft: 10, paddingRight: 1 }}>
-            <Ionicons name="ellipsis-vertical-sharp" size={22} color="white" />
-          </TouchableOpacity>
-        </RightNavigationView>
-      </NavigationView>
-
-      <ClubHeader clubData={data} heightExpanded={heightExpanded} heightCollapsed={heightCollapsed} headerDiff={headerDiff} scrollY={scrollY} />
+      <StatusBar translucent backgroundColor={"transparent"} barStyle={"dark-content"} />
+      <ClubHeader
+        clubData={data}
+        clubRole={clubRole?.data}
+        notiCount={notiCount}
+        openClubOptionModal={openClubOptionModal}
+        headerHeight={HEADER_HEIGHT}
+        heightExpanded={heightExpanded}
+        heightCollapsed={heightCollapsed}
+        headerDiff={headerDiff}
+        scrollY={scrollY}
+      />
 
       <Animated.View
+        pointerEvents="box-none"
         style={{
           position: "absolute",
           zIndex: 2,
           flex: 1,
           width: "100%",
-          height: SCREEN_HEIGHT + headerDiff,
+          height: SCREEN_HEIGHT + HEADER_EXPANDED_HEIGHT - HEADER_HEIGHT,
           paddingTop: heightExpanded,
           transform: [{ translateY }],
         }}

--- a/screens/ClubCreation/ClubCreationStepTwo.tsx
+++ b/screens/ClubCreation/ClubCreationStepTwo.tsx
@@ -8,6 +8,7 @@ import { useToast } from "react-native-toast-notifications";
 import { useMutation } from "react-query";
 import { ClubApi, DuplicateCheckResponse, DuplicateClubNameCheckRequest, ErrorResponse } from "../../api";
 import BottomButton from "../../components/BottomButton";
+import { lightTheme } from "../../theme";
 
 const HeaderView = styled.View`
   align-items: center;
@@ -57,7 +58,7 @@ const ContentItem = styled.View<{ error: boolean }>`
   width: 100%;
   flex: 1;
   border-bottom-width: 1px;
-  border-bottom-color: ${(props: any) => (props.error ? "#FF6534" : "#cecece")};
+  border-bottom-color: ${(props: any) => (props.error ? props.theme.accentColor : "#cecece")};
   margin: 10px 0px;
 `;
 
@@ -76,7 +77,7 @@ const ValidationItem = styled.View`
 
 const ValidationText = styled.Text`
   font-family: ${(props: any) => props.theme.koreanFontR};
-  color: #ff6534;
+  color: ${(props: any) => props.theme.accentColor};
   font-size: 10px;
   line-height: 15px;
 `;
@@ -94,7 +95,7 @@ const ErrorView = styled.View`
 const ErrorText = styled.Text`
   font-family: ${(props: any) => props.theme.koreanFontR};
   font-size: 12px;
-  color: #ff6534;
+  color: ${(props: any) => props.theme.accentColor};
 `;
 
 const Item = styled.View`
@@ -294,7 +295,7 @@ const ClubCreationStepTwo: React.FC<ClubCreationStepTwoScreenProps> = ({
                 />
                 {isDuplicatedName ? (
                   <ErrorView>
-                    <AntDesign name="exclamationcircleo" size={12} color="#ff6534" />
+                    <AntDesign name="exclamationcircleo" size={12} color={lightTheme.accentColor} />
                     <ErrorText>{` 이미 사용 중인 이름입니다.`}</ErrorText>
                   </ErrorView>
                 ) : (
@@ -305,7 +306,7 @@ const ClubCreationStepTwo: React.FC<ClubCreationStepTwoScreenProps> = ({
             <ValidationView>
               {specialChar.test(clubName) ? (
                 <ValidationItem>
-                  <AntDesign name="check" size={12} color={"#ff6534"} />
+                  <AntDesign name="check" size={12} color={lightTheme.accentColor} />
                   <ValidationText>{` 특수문자 불가능`}</ValidationText>
                 </ValidationItem>
               ) : (
@@ -313,7 +314,7 @@ const ClubCreationStepTwo: React.FC<ClubCreationStepTwoScreenProps> = ({
               )}
               {clubName.length - (clubName.split(" ").length - 1) > lengthLimit ? (
                 <ValidationItem>
-                  <AntDesign name="check" size={12} color={"#ff6534"} />
+                  <AntDesign name="check" size={12} color={lightTheme.accentColor} />
                   <ValidationText>{` ${lengthLimit}자 초과`}</ValidationText>
                 </ValidationItem>
               ) : (
@@ -356,7 +357,7 @@ const ClubCreationStepTwo: React.FC<ClubCreationStepTwoScreenProps> = ({
                 >
                   <ItemText>인원 수 무제한으로 받기</ItemText>
                   <CheckBox check={maxNumberInfinity}>
-                    <Ionicons name="checkmark-sharp" size={13} color={maxNumberInfinity ? "#FF6534" : "#e8e8e8"} />
+                    <Ionicons name="checkmark-sharp" size={13} color={maxNumberInfinity ? lightTheme.accentColor : "#e8e8e8"} />
                   </CheckBox>
                 </CheckButton>
               </Item>
@@ -368,7 +369,7 @@ const ClubCreationStepTwo: React.FC<ClubCreationStepTwoScreenProps> = ({
                   <Ionicons
                     name={isApproveRequired === "Y" ? "radio-button-on" : "radio-button-off"}
                     size={16}
-                    color={isApproveRequired === "Y" ? "#FF6534" : "rgba(0, 0, 0, 0.3)"}
+                    color={isApproveRequired === "Y" ? lightTheme.accentColor : "rgba(0, 0, 0, 0.3)"}
                     style={{ marginRight: 3 }}
                   />
                   <ItemText>관리자 승인 후 가입</ItemText>
@@ -377,7 +378,7 @@ const ClubCreationStepTwo: React.FC<ClubCreationStepTwoScreenProps> = ({
                   <Ionicons
                     name={isApproveRequired === "N" ? "radio-button-on" : "radio-button-off"}
                     size={16}
-                    color={isApproveRequired === "N" ? "#FF6534" : "rgba(0, 0, 0, 0.3)"}
+                    color={isApproveRequired === "N" ? lightTheme.accentColor : "rgba(0, 0, 0, 0.3)"}
                     style={{ marginRight: 3 }}
                   />
                   <ItemText>누구나 바로 가입</ItemText>

--- a/screens/ClubManagement/ClubEditBasics.tsx
+++ b/screens/ClubManagement/ClubEditBasics.tsx
@@ -9,6 +9,7 @@ import { Category, CategoryResponse, ClubApi, ClubUpdateRequest, ClubUpdateRespo
 import { useToast } from "react-native-toast-notifications";
 import CustomText from "../../components/CustomText";
 import CustomTextInput from "../../components/CustomTextInput";
+import { lightTheme } from "../../theme";
 
 const Container = styled.View`
   flex: 1;
@@ -49,7 +50,7 @@ const ContentItem = styled.View`
   width: 100%;
   flex: 1;
   border-bottom-width: 1px;
-  border-bottom-color: ${(props: any) => (props.error ? "#FF6534" : "#cecece")};
+  border-bottom-color: ${(props: any) => (props.error ? props.theme.accentColor : "#cecece")};
   padding-bottom: 3px;
   margin: 10px 0px;
 `;
@@ -68,7 +69,7 @@ const ValidationItem = styled.View`
 `;
 
 const ValidationText = styled(CustomText)`
-  color: #ff6534;
+  color: ${(props: any) => props.theme.accentColor};
   font-size: 10px;
   line-height: 15px;
 `;
@@ -84,7 +85,7 @@ const ErrorView = styled.View`
   align-items: center;
 `;
 const ErrorText = styled(CustomText)`
-  color: #ff6534;
+  color: ${(props: any) => props.theme.accentColor};
 `;
 
 const Item = styled.View`
@@ -348,7 +349,7 @@ const ClubEditBasics: React.FC<ClubEditBasicsProps> = ({
 
                 {isDuplicatedName ? (
                   <ErrorView>
-                    <AntDesign name="exclamationcircleo" size={12} color="#ff6534" />
+                    <AntDesign name="exclamationcircleo" size={12} color={lightTheme.accentColor} />
                     <ErrorText>{` 이미 사용 중인 이름입니다.`}</ErrorText>
                   </ErrorView>
                 ) : (
@@ -360,7 +361,7 @@ const ClubEditBasics: React.FC<ClubEditBasicsProps> = ({
             <ValidationView>
               {specialChar.test(clubName) ? (
                 <ValidationItem>
-                  <AntDesign name="check" size={12} color={"#ff6534"} />
+                  <AntDesign name="check" size={12} color={lightTheme.accentColor} />
                   <ValidationText>{` 특수문자 불가능`}</ValidationText>
                 </ValidationItem>
               ) : (
@@ -368,7 +369,7 @@ const ClubEditBasics: React.FC<ClubEditBasicsProps> = ({
               )}
               {clubName.length - (clubName.split(" ").length - 1) > lengthLimit ? (
                 <ValidationItem>
-                  <AntDesign name="check" size={12} color={"#ff6534"} />
+                  <AntDesign name="check" size={12} color={lightTheme.accentColor} />
                   <ValidationText>{` ${lengthLimit}자 초과`}</ValidationText>
                 </ValidationItem>
               ) : (
@@ -413,7 +414,7 @@ const ClubEditBasics: React.FC<ClubEditBasicsProps> = ({
                 >
                   <ItemText>인원 수 무제한으로 받기</ItemText>
                   <CheckBox check={maxNumberInfinity}>
-                    <Ionicons name="checkmark-sharp" size={13} color={maxNumberInfinity ? "#FF6534" : "#e8e8e8"} />
+                    <Ionicons name="checkmark-sharp" size={13} color={maxNumberInfinity ? lightTheme.accentColor : "#e8e8e8"} />
                   </CheckBox>
                 </CheckButton>
               </Item>
@@ -425,7 +426,7 @@ const ClubEditBasics: React.FC<ClubEditBasicsProps> = ({
                   <Ionicons
                     name={isApproveRequired === "Y" ? "radio-button-on" : "radio-button-off"}
                     size={16}
-                    color={isApproveRequired === "Y" ? "#FF6534" : "rgba(0, 0, 0, 0.3)"}
+                    color={isApproveRequired === "Y" ? lightTheme.accentColor : "rgba(0, 0, 0, 0.3)"}
                     style={{ marginRight: 3 }}
                   />
                   <ItemText>관리자 승인 후 가입</ItemText>
@@ -434,7 +435,7 @@ const ClubEditBasics: React.FC<ClubEditBasicsProps> = ({
                   <Ionicons
                     name={isApproveRequired === "N" ? "radio-button-on" : "radio-button-off"}
                     size={16}
-                    color={isApproveRequired === "N" ? "#FF6534" : "rgba(0, 0, 0, 0.3)"}
+                    color={isApproveRequired === "N" ? lightTheme.accentColor : "rgba(0, 0, 0, 0.3)"}
                     style={{ marginRight: 3 }}
                   />
                   <ItemText>누구나 바로 가입</ItemText>

--- a/screens/ClubManagement/ClubEditMembers.tsx
+++ b/screens/ClubManagement/ClubEditMembers.tsx
@@ -12,6 +12,7 @@ import { useSelector } from "react-redux";
 import { useMutation } from "react-query";
 import { ClubApi } from "../../api";
 import { RootState } from "../../redux/store/reducers";
+import { lightTheme } from "../../theme";
 
 const Container = styled.View`
   flex: 1;
@@ -285,41 +286,41 @@ const ClubEditMembers: React.FC<ClubEditMembersProps> = ({
                       item.role === "MASTER" ? (
                         <>
                           <MenuItem onPress={() => changeRole(item, "MEMBER")} style={{ margin: -10 }}>
-                            <AntDesign name="closecircleo" size={12} color="#FF6534" />
+                            <AntDesign name="closecircleo" size={12} color={lightTheme.accentColor} />
                             <ItemText>{` 리더 지정 취소`}</ItemText>
                           </MenuItem>
                           <MenuDivider />
                           <MenuItem onPress={() => changeRole(item, "MANAGER")} style={{ margin: -10 }}>
-                            <AntDesign name="checkcircle" size={12} color="#FF6534" />
+                            <AntDesign name="checkcircle" size={12} color={lightTheme.accentColor} />
                             <ItemText>{` 매니저 지정`}</ItemText>
                           </MenuItem>
                         </>
                       ) : item.role === "MANAGER" ? (
                         <>
                           <MenuItem onPress={() => changeRole(item, "MASTER")} style={{ margin: -10 }}>
-                            <AntDesign name="star" size={12} color="#FF6534" />
+                            <AntDesign name="star" size={12} color={lightTheme.accentColor} />
                             <ItemText>{` 리더 지정`}</ItemText>
                           </MenuItem>
                           <MenuDivider />
                           <MenuItem onPress={() => changeRole(item, "MEMBER")} style={{ margin: -10 }}>
-                            <AntDesign name="closecircleo" size={12} color="#FF6534" />
+                            <AntDesign name="closecircleo" size={12} color={lightTheme.accentColor} />
                             <ItemText>{` 매니저 지정 취소`}</ItemText>
                           </MenuItem>
                         </>
                       ) : (
                         <>
                           <MenuItem onPress={() => changeRole(item, "MASTER")} style={{ margin: -10 }}>
-                            <AntDesign name="star" size={12} color="#FF6534" />
+                            <AntDesign name="star" size={12} color={lightTheme.accentColor} />
                             <ItemText>{` 리더 지정`}</ItemText>
                           </MenuItem>
                           <MenuDivider />
                           <MenuItem onPress={() => changeRole(item, "MANAGER")} style={{ margin: -10 }}>
-                            <AntDesign name="checkcircle" size={12} color="#FF6534" />
+                            <AntDesign name="checkcircle" size={12} color={lightTheme.accentColor} />
                             <ItemText>{` 매니저 지정`}</ItemText>
                           </MenuItem>
                           <MenuDivider />
                           <MenuItem onPress={() => kickOut(item.id)} style={{ margin: -10 }}>
-                            <AntDesign name="deleteuser" size={12} color="#FF6534" />
+                            <AntDesign name="deleteuser" size={12} color={lightTheme.accentColor} />
                             <ItemText>{` 강제 탈퇴`}</ItemText>
                           </MenuItem>
                         </>
@@ -327,7 +328,7 @@ const ClubEditMembers: React.FC<ClubEditMembersProps> = ({
                     ) : (
                       <>
                         <MenuItem onPress={() => cancelKickOut(item.id)} style={{ margin: -10 }}>
-                          <AntDesign name="deleteuser" size={12} color="#FF6534" />
+                          <AntDesign name="deleteuser" size={12} color={lightTheme.accentColor} />
                           <ItemText>{` 강제 탈퇴 취소`}</ItemText>
                         </MenuItem>
                       </>

--- a/screens/ClubManagement/ClubManagementMain.tsx
+++ b/screens/ClubManagement/ClubManagementMain.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import { Alert, Animated, BackHandler, DeviceEventEmitter, StatusBar, TouchableOpacity } from "react-native";
+import { Alert, Animated, BackHandler, DeviceEventEmitter, Platform, StatusBar, TouchableOpacity } from "react-native";
 import styled from "styled-components/native";
 import { Feather, AntDesign, FontAwesome5, Entypo, Ionicons } from "@expo/vector-icons";
 import { ClubManagementMainProps, ClubStackParamList } from "../../types/Club";
@@ -15,6 +15,7 @@ import { RootState } from "../../redux/store/reducers";
 import Tag from "../../components/Tag";
 
 const Container = styled.SafeAreaView`
+  padding-top: ${Platform.OS === "android" ? StatusBar.currentHeight : 0}px;
   flex: 1;
 `;
 

--- a/screens/ClubManagement/ClubManagementMain.tsx
+++ b/screens/ClubManagement/ClubManagementMain.tsx
@@ -139,7 +139,7 @@ const ClubManagementMain: React.FC<ClubManagementMainProps> = ({
     params: { clubData, refresh },
   },
 }) => {
-  const myRole = useSelector((state: RootState) => state.club.role);
+  const myRole = useSelector((state: RootState) => state.club[clubData.id]?.role);
   const toast = useToast();
   const [data, setData] = useState<Club>(clubData);
   const [isToggle, setIsToggle] = useState(clubData?.recruitStatus === "OPEN" ? true : false);

--- a/screens/Clubs.tsx
+++ b/screens/Clubs.tsx
@@ -11,6 +11,7 @@ import { Portal } from "react-native-portalize";
 import { Slider } from "@miblanchard/react-native-slider";
 import { useToast } from "react-native-toast-notifications";
 import BottomButton from "../components/BottomButton";
+import { lightTheme } from "../theme";
 
 const Loader = styled.SafeAreaView`
   flex: 1;
@@ -159,7 +160,7 @@ const SortingItemButton = styled.TouchableOpacity`
 `;
 const SortingItemText = styled.Text<{ selected: boolean }>`
   font-size: 15px;
-  color: ${(props: any) => (props.selected ? "#EC5D56" : "#b0b0b0")};
+  color: ${(props: any) => (props.selected ? props.theme.accentColor : "#b0b0b0")};
   font-family: ${(props: any) => (props.selected ? props.theme.koreanFontM : props.theme.koreanFontR)};
 `;
 
@@ -385,7 +386,7 @@ const Clubs: React.FC<ClubListScreenProps> = ({ navigation: { navigate } }) => {
                 <HeaderItemText>상세 필터</HeaderItemText>
               </TouchableOpacity>
               <TouchableOpacity style={{ height: 35, justifyContent: "center" }} onPress={() => openFilteringSheet()}>
-                <Feather name="filter" size={13} color={usingFilter ? "#EC5D56" : "black"} />
+                <Feather name="filter" size={13} color={usingFilter ? lightTheme.accentColor : "black"} />
               </TouchableOpacity>
             </HeaderItem>
             <View
@@ -500,7 +501,7 @@ const Clubs: React.FC<ClubListScreenProps> = ({ navigation: { navigate } }) => {
                 >
                   <ItemContentText>멤버 모집중인 모임만 보기</ItemContentText>
                   <CheckBox>
-                    <Ionicons name="checkmark-sharp" size={15} color={showRecruiting ? "#EC5D56" : "white"} />
+                    <Ionicons name="checkmark-sharp" size={15} color={showRecruiting ? lightTheme.accentColor : "white"} />
                   </CheckBox>
                 </ItemContentButton>
               </ItemRightView>
@@ -522,13 +523,13 @@ const Clubs: React.FC<ClubListScreenProps> = ({ navigation: { navigate } }) => {
                   }}
                   onSlidingComplete={(value) => setMemberRange(value)}
                   minimumValue={filterMinNumber}
-                  minimumTrackTintColor="#EC5D56"
+                  minimumTrackTintColor={lightTheme.accentColor}
                   maximumValue={filterMaxNumber}
                   maximumTrackTintColor="#E8E8E8"
                   step={5}
                   thumbTintColor="white"
                   trackStyle={{ height: 2 }}
-                  thumbStyle={{ width: 18, height: 18, borderWidth: 1, borderColor: "#EC5D56" }}
+                  thumbStyle={{ width: 18, height: 18, borderWidth: 1, borderColor: lightTheme.accentColor }}
                 />
                 <ItemContentSubText>{Array.isArray(memberRange) ? `최소 ${memberRange[0]} 명 이상 최대 ${memberRange[1]} 명 이하` : ``}</ItemContentSubText>
               </ItemRightView>
@@ -546,7 +547,7 @@ const Clubs: React.FC<ClubListScreenProps> = ({ navigation: { navigate } }) => {
                 >
                   <ItemContentText>내가 가입된 모임만 보기</ItemContentText>
                   <CheckBox>
-                    <Ionicons name="checkmark-sharp" size={15} color={showMy ? "#EC5D56" : "#e8e8e8"} />
+                    <Ionicons name="checkmark-sharp" size={15} color={showMy ? lightTheme.accentColor : "#e8e8e8"} />
                   </CheckBox>
                 </ItemContentButton>
               </ItemRightView>

--- a/screens/Clubs.tsx
+++ b/screens/Clubs.tsx
@@ -37,6 +37,7 @@ const SelectedCategoryName = styled.Text`
 `;
 
 const Container = styled.SafeAreaView`
+  padding-top: ${Platform.OS === "android" ? StatusBar.currentHeight : 0}px;
   flex: 1;
 `;
 
@@ -355,6 +356,7 @@ const Clubs: React.FC<ClubListScreenProps> = ({ navigation: { navigate } }) => {
   ) : (
     <>
       <Container>
+        <StatusBar translucent backgroundColor={"white"} barStyle={"dark-content"} />
         <HeaderView>
           <FlatList
             showsHorizontalScrollIndicator={false}

--- a/screens/Feed/FeedComments.tsx
+++ b/screens/Feed/FeedComments.tsx
@@ -132,7 +132,7 @@ const FeedComments = ({
       setIsLoading(false);
       if (feedIndex !== undefined) {
         const count = res.data.length + res.data.reduce((acc, comment) => acc + comment.replies.length, 0);
-        if (clubId) dispatch(clubSlice.actions.updateCommentCount({ feedIndex, count }));
+        if (clubId) dispatch(clubSlice.actions.updateCommentCount({ clubId, feedIndex, count }));
         else dispatch(feedSlice.actions.updateCommentCount({ feedIndex, count }));
       } else {
         DeviceEventEmitter.emit("SelectFeedRefetch");

--- a/screens/Feed/FeedLikes.tsx
+++ b/screens/Feed/FeedLikes.tsx
@@ -1,11 +1,12 @@
 import { Entypo } from "@expo/vector-icons";
+import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import React, { useCallback, useLayoutEffect } from "react";
 import { FlatList, TouchableOpacity, View } from "react-native";
 import styled from "styled-components/native";
 import { LikeUser } from "../../api";
 import CircleIcon from "../../components/CircleIcon";
 
-const Container = styled.View`
+const Container = styled.TouchableOpacity`
   flex-direction: row;
   justify-content: flex-start;
   align-items: center;
@@ -18,8 +19,8 @@ const NameText = styled.Text`
   color: #2b2b2b;
 `;
 
-const FeedLikes = ({
-  navigation: { setOptions, navigate, goBack },
+const FeedLikes: React.FC<NativeStackScreenProps<any, "FeedLikes">> = ({
+  navigation: { setOptions, navigate, goBack, push },
   route: {
     params: { likeUsers },
   },
@@ -28,8 +29,8 @@ const FeedLikes = ({
   const ItemSeparatorComponent = useCallback(() => <View style={{ height: 10 }} />, []);
   const renderItem = useCallback(
     ({ item, index }: { item: LikeUser; index: number }) => (
-      <Container>
-        <CircleIcon size={36} uri={item.thumbnail} kerning={8} />
+      <Container activeOpacity={1} onPress={() => goToProfile(item.userId)}>
+        <CircleIcon size={36} uri={item.thumbnail} kerning={8} onPress={() => goToProfile(item.userId)} />
         <NameText>{item.userName}</NameText>
       </Container>
     ),
@@ -45,6 +46,8 @@ const FeedLikes = ({
       ),
     });
   }, []);
+
+  const goToProfile = (userId: number) => push("ProfileStack", { screen: "Profile", params: { userId } });
 
   return (
     <FlatList

--- a/screens/Feed/FeedSelection.tsx
+++ b/screens/Feed/FeedSelection.tsx
@@ -87,22 +87,9 @@ const FeedSelection = ({
     },
   });
 
-  const goToClub = (clubId?: number) => {
-    if (clubId) navigate("ClubStack", { screen: "ClubTopTabs", params: { clubData: { id: clubId } } });
-  };
-
   const goToComplain = () => {
     closeFeedOption();
     openComplainOption();
-  };
-
-  const goToFeedComments = (feedIndex?: number, feedId?: number) => {
-    navigate("FeedStack", { screen: "FeedComments", params: { feedIndex, feedId: feedId ?? selectFeedId, clubId: feedData?.clubId } });
-  };
-
-  const goToFeedLikes = (likeUsers?: LikeUser[]) => {
-    if (!likeUsers || likeUsers.length === 0) return;
-    navigate("FeedStack", { screen: "FeedLikes", params: { likeUsers } });
   };
 
   const goToUpdateFeed = () => {
@@ -268,10 +255,7 @@ const FeedSelection = ({
         infoHeight={feedDetailInfoHeight}
         contentHeight={feedDetailContentHeight}
         goToFeedOptionModal={goToFeedOptionModal}
-        goToFeedComments={goToFeedComments}
-        goToFeedLikes={goToFeedLikes}
         likeFeed={likeFeed}
-        goToClub={goToClub}
         showClubName={true}
       />
 

--- a/screens/Home.tsx
+++ b/screens/Home.tsx
@@ -202,19 +202,6 @@ const Home = () => {
       toast.show(`${error.message ?? error.code}`, { type: "warning" });
     },
   });
-  const goToClub = useCallback((clubId?: number) => {
-    if (clubId) navigation.navigate("ClubStack", { screen: "ClubTopTabs", params: { clubData: { id: clubId } } });
-  }, []);
-
-  const goToFeedComments = useCallback((feedIndex?: number, feedId?: number) => {
-    if (feedIndex === undefined || feedId === undefined) return;
-    navigation.navigate("FeedStack", { screen: "FeedComments", params: { feedIndex, feedId } });
-  }, []);
-
-  const goToFeedLikes = useCallback((likeUsers?: LikeUser[]) => {
-    if (!likeUsers || likeUsers.length === 0) return;
-    navigation.navigate("FeedStack", { screen: "FeedLikes", params: { likeUsers } });
-  }, []);
 
   const goToUpdateFeed = () => {
     closeFeedOption();
@@ -368,10 +355,7 @@ const Home = () => {
         infoHeight={feedDetailInfoHeight}
         contentHeight={feedDetailContentHeight}
         showClubName={true}
-        goToClub={goToClub}
         goToFeedOptionModal={goToFeedOptionModal}
-        goToFeedComments={goToFeedComments}
-        goToFeedLikes={goToFeedLikes}
         likeFeed={likeFeed}
       />
     ),

--- a/screens/Home.tsx
+++ b/screens/Home.tsx
@@ -63,7 +63,7 @@ const NotiBadge = styled.View`
   height: 5px;
   border-radius: 5px;
   z-index: 1;
-  background-color: #ff6534;
+  background-color: ${(props: any) => props.theme.accentColor};
   justify-content: center;
   align-items: center;
 `;

--- a/screens/Home.tsx
+++ b/screens/Home.tsx
@@ -25,6 +25,7 @@ const Loader = styled.SafeAreaView`
 `;
 
 const Container = styled.SafeAreaView`
+  padding-top: ${Platform.OS === "android" ? StatusBar.currentHeight : 0}px;
   flex: 1;
 `;
 
@@ -383,7 +384,7 @@ const Home = () => {
     </Loader>
   ) : (
     <Container>
-      <StatusBar backgroundColor={"white"} barStyle={"dark-content"} />
+      <StatusBar translucent backgroundColor={"white"} barStyle={"dark-content"} />
       <HeaderView height={homeHeaderHeight}>
         <LogoText>{`ON YOU`}</LogoText>
         <HeaderRightView>

--- a/screens/Login/FindEmail.tsx
+++ b/screens/Login/FindEmail.tsx
@@ -16,9 +16,9 @@ const Container = styled.View`
 const Content = styled.View``;
 
 const ContentTitle = styled.Text`
-  font-family: "AppleSDGothicNeoSB";
+  font-family: ${(props: any) => props.theme.koreanFontSB};
   font-size: 16px;
-  color: #aeaeae;
+  color: ${(props: any) => props.theme.infoColor};
   margin-bottom: 8px;
 `;
 
@@ -31,7 +31,7 @@ const PhoneNumberView = styled.View`
 `;
 
 const ContentInput = styled.TextInput`
-  font-family: "AppleSDGothicNeoR";
+  font-family: ${(props: any) => props.theme.koreanFontR};
   border-bottom-width: 0.5px;
   border-bottom-color: #000000;
   padding-bottom: 2px;
@@ -121,7 +121,7 @@ const FindEmail: React.FC<NativeStackScreenProps<any, "FindEmail">> = ({ navigat
           </Content>
         </Container>
       </TouchableWithoutFeedback>
-      <BottomButton onPress={onSubmit} backgroundColor="#6B8BF7" disabled={!(userName.trim() && phoneNumber.trim())} title={"확인"} />
+      <BottomButton onPress={onSubmit} disabled={!(userName.trim() && phoneNumber.trim())} title={"확인"} />
     </>
   );
 };

--- a/screens/Login/FindLoginInfo.tsx
+++ b/screens/Login/FindLoginInfo.tsx
@@ -2,6 +2,7 @@ import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import React, { useState } from "react";
 import { StatusBar } from "react-native";
 import styled from "styled-components/native";
+import { lightTheme } from "../../theme";
 
 const Container = styled.SafeAreaView`
   flex: 1;
@@ -33,13 +34,13 @@ const Button = styled.TouchableHighlight`
   height: 55px;
   border-radius: 30px;
   border-width: 1px;
-  border-color: #6b8bf7;
+  border-color: ${(props: any) => props.theme.primaryColor};
   background-color: #fff;
   margin-bottom: 25px;
 `;
 
 const Title = styled.Text<{ color: string }>`
-  font-family: "AppleSDGothicNeoSB";
+  font-family: ${(props: any) => props.theme.koreanFontSB};
   line-height: 26px;
   font-size: 22px;
   padding-left: 5px;
@@ -62,12 +63,12 @@ const FindLoginInfo: React.FC<NativeStackScreenProps<any, "FindLoginInfo">> = ({
     <Container>
       <StatusBar backgroundColor={"white"} barStyle={"dark-content"} />
       <TopView>
-        <Button onPressIn={() => setFindEmailColor("white")} onPressOut={() => setFindEmailColor("black")} onPress={goToFindEmail} underlayColor="#6B8BF7">
+        <Button onPressIn={() => setFindEmailColor("white")} onPressOut={() => setFindEmailColor("black")} onPress={goToFindEmail} underlayColor={lightTheme.primaryColor}>
           <TitleView>
             <Title color={findEmailColor}>E-mail 찾기</Title>
           </TitleView>
         </Button>
-        <Button onPressIn={() => setFindPasswordColor("white")} onPressOut={() => setFindPasswordColor("black")} onPress={goToFindPasswrod} underlayColor="#6B8BF7">
+        <Button onPressIn={() => setFindPasswordColor("white")} onPressOut={() => setFindPasswordColor("black")} onPress={goToFindPasswrod} underlayColor={lightTheme.primaryColor}>
           <TitleView>
             <Title color={findPasswordColor}>비밀번호 찾기</Title>
           </TitleView>

--- a/screens/Login/FindPassword.tsx
+++ b/screens/Login/FindPassword.tsx
@@ -16,9 +16,9 @@ const Container = styled.View`
 const Content = styled.View``;
 
 const ContentTitle = styled.Text`
-  font-family: "AppleSDGothicNeoSB";
+  font-family: ${(props: any) => props.theme.koreanFontSB};
   font-size: 16px;
-  color: #aeaeae;
+  color: ${(props: any) => props.theme.infoColor};
   margin-bottom: 8px;
 `;
 
@@ -27,7 +27,7 @@ const ItemView = styled.View`
 `;
 
 const ContentInput = styled.TextInput`
-  font-family: "AppleSDGothicNeoR";
+  font-family: ${(props: any) => props.theme.koreanFontR};
   border-bottom-width: 0.5px;
   border-bottom-color: #000000;
   padding-bottom: 2px;
@@ -156,7 +156,7 @@ const FindPassword: React.FC<NativeStackScreenProps<any, "FindPassword">> = ({ n
           </Content>
         </Container>
       </TouchableWithoutFeedback>
-      <BottomButton onPress={onSubmit} backgroundColor="#6B8BF7" disabled={!(userName.trim() && phoneNumber.trim() && userEmail.trim() && birthNumber.trim())} title={"확인"} />
+      <BottomButton onPress={onSubmit} disabled={!(userName.trim() && phoneNumber.trim() && userEmail.trim() && birthNumber.trim())} title={"확인"} />
     </>
   );
 };

--- a/screens/Login/FindResult.tsx
+++ b/screens/Login/FindResult.tsx
@@ -18,37 +18,37 @@ const Header = styled.View`
 
 const LineView = styled.View`
   height: 1.5px;
-  background-color: #aeaeae;
+  background-color: ${(props: any) => props.theme.infoColor};
 `;
 
 const HeaderTitle = styled.Text`
-  font-family: "Roboto-Medium";
+  font-family: ${(props: any) => props.theme.englishFontM};
   font-size: 40px;
   line-height: 43px;
 `;
 
 const HeaderText = styled.Text`
-  font-family: "AppleSDGothicNeoR";
+  font-family: ${(props: any) => props.theme.koreanFontR};
   font-size: 16px;
-  color: #aeaeae;
+  color: ${(props: any) => props.theme.infoColor};
   margin-top: 10px;
 `;
 
 const Content = styled.View``;
 
 const ContentTitle = styled.Text`
-  font-family: "Roboto-Bold";
+  font-family: ${(props: any) => props.theme.englishFontB};
   font-size: 26px;
 `;
 const ContentText = styled.Text`
-  font-family: "AppleSDGothicNeoR";
+  font-family: ${(props: any) => props.theme.koreanFontR};
   font-size: 16px;
 `;
 
 const ContentSubText = styled.Text`
-  font-family: "AppleSDGothicNeoR";
+  font-family: ${(props: any) => props.theme.koreanFontR};
   font-size: 14px;
-  color: #aeaeae;
+  color: ${(props: any) => props.theme.infoColor};
 `;
 
 const Button = styled.TouchableOpacity`
@@ -108,7 +108,7 @@ const FindResult: React.FC<NativeStackScreenProps<any, "FindResult">> = ({
           </View>
         )}
       </Content>
-      <BottomButton onPress={goToLogin} backgroundColor="#6B8BF7" title={"로그인으로"} />
+      <BottomButton onPress={goToLogin} title={"로그인으로"} />
     </Container>
   );
 };

--- a/screens/Login/Login.tsx
+++ b/screens/Login/Login.tsx
@@ -2,7 +2,7 @@ import { useMutation } from "react-query";
 import { CommonApi, LoginRequest, LoginResponse } from "../../api";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import React, { useState } from "react";
-import { Keyboard, SafeAreaView, StatusBar, TouchableWithoutFeedback } from "react-native";
+import { Keyboard, Platform, SafeAreaView, StatusBar, TouchableWithoutFeedback } from "react-native";
 import styled from "styled-components/native";
 import { useToast } from "react-native-toast-notifications";
 import { useAppDispatch } from "../../redux/store";
@@ -20,14 +20,14 @@ const Header = styled.View`
 `;
 
 const HeaderTitle = styled.Text`
-  font-family: "Roboto-Medium";
+  font-family: ${(props: any) => props.theme.englishFontM};
   font-size: 40px;
 `;
 
 const Content = styled.View``;
 
 const ContentTitle = styled.Text`
-  font-family: "Roboto-Medium";
+  font-family: ${(props: any) => props.theme.englishFontM};
   font-size: 16px;
   color: #aeaeae;
   margin-bottom: 8px;
@@ -42,7 +42,7 @@ const PasswordView = styled.View`
 `;
 
 const ContentInput = styled.TextInput`
-  font-family: "Roboto-Regular";
+  font-family: ${(props: any) => props.theme.englishFontR};
   border-bottom-width: 0.5px;
   border-bottom-color: #000000;
   padding-bottom: 2px;
@@ -55,7 +55,7 @@ const InformationView = styled.TouchableOpacity`
 `;
 
 const InformationText = styled.Text`
-  font-family: "AppleSDGothicNeoSB";
+  font-family: ${(props: any) => props.theme.koreanFontSB};
   font-size: 14px;
   color: #777777;
 `;
@@ -101,7 +101,7 @@ const Login: React.FC<NativeStackScreenProps<any, "Login">> = ({ navigation: { n
   };
 
   return (
-    <SafeAreaView>
+    <SafeAreaView style={{ paddingTop: Platform.OS === "android" ? StatusBar.currentHeight : 0 }}>
       <TouchableWithoutFeedback
         onPress={() => {
           Keyboard.dismiss();

--- a/screens/Login/Login.tsx
+++ b/screens/Login/Login.tsx
@@ -29,7 +29,7 @@ const Content = styled.View``;
 const ContentTitle = styled.Text`
   font-family: ${(props: any) => props.theme.englishFontM};
   font-size: 16px;
-  color: #aeaeae;
+  color: ${(props: any) => props.theme.infoColor};
   margin-bottom: 8px;
 `;
 
@@ -127,7 +127,7 @@ const Login: React.FC<NativeStackScreenProps<any, "Login">> = ({ navigation: { n
           </Content>
         </Container>
       </TouchableWithoutFeedback>
-      <BottomButton onPress={onSubmit} disabled={!(email.trim() && password)} backgroundColor="#6B8BF7" title={"확인"} />
+      <BottomButton onPress={onSubmit} disabled={!(email.trim() && password)} title={"확인"} />
     </SafeAreaView>
   );
 };

--- a/screens/Preferences/AccountEdit.tsx
+++ b/screens/Preferences/AccountEdit.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
-import { TouchableOpacity, Text, Platform, KeyboardAvoidingView, DeviceEventEmitter, ActivityIndicator, ScrollView, View } from "react-native";
+import { TouchableOpacity, Platform, KeyboardAvoidingView, DeviceEventEmitter, ActivityIndicator, ScrollView, View } from "react-native";
 import styled from "styled-components/native";
 import ImagePicker from "react-native-image-crop-picker";
 import { useMutation } from "react-query";
@@ -10,7 +10,6 @@ import RNDateTimePicker from "@react-native-community/datetimepicker";
 import DatePicker from "react-native-date-picker";
 import CustomText from "../../components/CustomText";
 import { useToast } from "react-native-toast-notifications";
-import CustomTextInput from "../../components/CustomTextInput";
 import CircleIcon from "../../components/CircleIcon";
 import { AntDesign, Entypo, Ionicons } from "@expo/vector-icons";
 
@@ -24,7 +23,7 @@ const Content = styled.View`
   margin-bottom: 20px;
 `;
 
-const ContentItem = styled.View<{ error: boolean }>`
+const ContentItem = styled.View<{ error?: boolean }>`
   width: 100%;
   flex: 1;
   border-bottom-width: 1px;
@@ -32,21 +31,23 @@ const ContentItem = styled.View<{ error: boolean }>`
   margin: 10px 0px;
 `;
 
-const ItemTitle = styled(CustomText)`
+const ItemTitle = styled.Text`
+  font-family: ${(props: any) => props.theme.koreanFontR};
   font-size: 13px;
-  line-height: 19px;
   color: #b0b0b0;
   margin-bottom: 5px;
 `;
 
-const ItemText = styled(CustomText)<{ disabled: boolean }>`
+const ItemText = styled.Text<{ disabled: boolean }>`
+  font-family: ${(props: any) => props.theme.koreanFontR};
   padding: 2px 0px;
   font-size: 15px;
   line-height: 22px;
   color: ${(props: any) => (props.disabled ? "#6F6F6F" : "black")};
 `;
 
-const ItemTextInput = styled(CustomTextInput)`
+const ItemTextInput = styled.TextInput`
+  font-family: ${(props: any) => props.theme.koreanFontR};
   font-size: 15px;
   line-height: 22px;
   flex: 1;
@@ -65,10 +66,10 @@ const ValidationItem = styled.View`
   margin-right: 8px;
 `;
 
-const ValidationText = styled(CustomText)`
+const ValidationText = styled.Text`
+  font-family: ${(props: any) => props.theme.koreanFontR};
   color: #ff6534;
   font-size: 10px;
-  line-height: 15px;
 `;
 
 const RadioButtonView = styled.View`
@@ -82,16 +83,17 @@ const RadioButton = styled.TouchableOpacity`
   margin-right: 10px;
 `;
 
-const ImagePickerButton = styled.TouchableOpacity<{ size: number }>`
+const ImagePickerButton = styled.TouchableOpacity`
   justify-content: center;
   align-items: center;
-  margin-top: 35px;
+  margin-top: 20px;
   margin-bottom: 10px;
 `;
 
-const ProfileText = styled(CustomText)`
+const ProfileText = styled.Text`
+  font-family: ${(props: any) => props.theme.koreanFontR}
   margin-top: 10px;
-  font-size: 12px;
+  font-size: 14px;
   color: #2995fa;
 `;
 
@@ -103,7 +105,7 @@ const DateView = styled.View`
   margin: 5px 0px;
 `;
 
-const EditAccount: React.FC<NativeStackScreenProps<any, "EditAccount">> = ({ route: { params: userData }, navigation: { navigate, goBack, setOptions } }) => {
+const AccountEdit: React.FC<NativeStackScreenProps<any, "AccountEdit">> = ({ route: { params: userData }, navigation: { navigate, goBack, setOptions } }) => {
   const [imageURI, setImageURI] = useState<string | null>(userData?.thumbnail);
   const [name, setName] = useState<string>(userData?.name);
   const [nameErrorCheck, setNameErrorCheck] = useState<boolean>(false);
@@ -114,7 +116,7 @@ const EditAccount: React.FC<NativeStackScreenProps<any, "EditAccount">> = ({ rou
   const [organizationName, setOrganizationName] = useState<string>(userData?.organizationName);
   const [showDatePicker, setShowDatePicker] = useState<boolean>(false);
   const toast = useToast();
-  const imageSize = 85;
+  const imageSize = 100;
   const specialChar = /[\{\}\[\]\/?.,;:|\)*~`!^\-_+<>@\#$%&\\\=\(\'\"]+/;
 
   const mutation = useMutation<BaseResponse, ErrorResponse, UserUpdateRequest>(UserApi.updateUserInfo, {
@@ -140,8 +142,6 @@ const EditAccount: React.FC<NativeStackScreenProps<any, "EditAccount">> = ({ rou
       organization: organizationName.trim(),
       phoneNumber: phoneNumber?.trim() ?? null,
     };
-
-    console.log(data);
 
     const splitedURI = new String(imageURI).split("/");
 
@@ -208,7 +208,7 @@ const EditAccount: React.FC<NativeStackScreenProps<any, "EditAccount">> = ({ rou
   }, [phoneNumber]);
 
   return (
-    <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : undefined} keyboardVerticalOffset={100} style={{ flex: 1 }}>
+    <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : undefined} keyboardVerticalOffset={100} style={{ flex: 1, backgroundColor: "white" }}>
       <ScrollView
         contentContainerStyle={{
           justifyContent: "space-between",
@@ -220,12 +220,12 @@ const EditAccount: React.FC<NativeStackScreenProps<any, "EditAccount">> = ({ rou
           <HeaderView>
             <ImagePickerButton onPress={pickImage} activeOpacity={1}>
               <CircleIcon size={imageSize} uri={imageURI} />
-              <ProfileText onPress={pickImage}>프로필 사진 설정</ProfileText>
+              <ProfileText onPress={pickImage}>{`프로필 사진 설정`}</ProfileText>
             </ImagePickerButton>
           </HeaderView>
           <Content>
             <ContentItem error={nameErrorCheck} style={{ marginBottom: 0 }}>
-              <ItemTitle>이름</ItemTitle>
+              <ItemTitle>{`이름`}</ItemTitle>
               <ItemTextInput
                 value={name}
                 placeholder={`홍길동`}
@@ -255,7 +255,7 @@ const EditAccount: React.FC<NativeStackScreenProps<any, "EditAccount">> = ({ rou
               )}
             </ValidationView>
             <ContentItem style={{ marginTop: 2 }}>
-              <ItemTitle>성별</ItemTitle>
+              <ItemTitle>{`성별`}</ItemTitle>
               <RadioButtonView>
                 <RadioButton onPress={() => setSex("M")} disabled={!shouldSelectSex}>
                   <Ionicons
@@ -278,11 +278,11 @@ const EditAccount: React.FC<NativeStackScreenProps<any, "EditAccount">> = ({ rou
               </RadioButtonView>
             </ContentItem>
             <ContentItem>
-              <ItemTitle>이메일</ItemTitle>
+              <ItemTitle>{`이메일`}</ItemTitle>
               <ItemText>{userData?.email}</ItemText>
             </ContentItem>
             <ContentItem>
-              <ItemTitle>생년월일</ItemTitle>
+              <ItemTitle>{`생년월일`}</ItemTitle>
               <CollapsibleButton collapsed={showDatePicker} onPress={() => setShowDatePicker((prev) => !prev)}>
                 <ItemText>{birthday}</ItemText>
               </CollapsibleButton>
@@ -301,7 +301,7 @@ const EditAccount: React.FC<NativeStackScreenProps<any, "EditAccount">> = ({ rou
               )}
             </ContentItem>
             <ContentItem>
-              <ItemTitle>연락처</ItemTitle>
+              <ItemTitle>{`연락처`}</ItemTitle>
               <ItemTextInput
                 keyboardType="numeric"
                 value={phoneNumber}
@@ -316,7 +316,7 @@ const EditAccount: React.FC<NativeStackScreenProps<any, "EditAccount">> = ({ rou
               />
             </ContentItem>
             <ContentItem>
-              <ItemTitle>교회</ItemTitle>
+              <ItemTitle>{`교회`}</ItemTitle>
               {/* <ItemText>{`시광교회`}</ItemText> */}
               <ItemTextInput
                 value={organizationName}
@@ -337,4 +337,4 @@ const EditAccount: React.FC<NativeStackScreenProps<any, "EditAccount">> = ({ rou
   );
 };
 
-export default EditAccount;
+export default AccountEdit;

--- a/screens/Preferences/AccountEdit.tsx
+++ b/screens/Preferences/AccountEdit.tsx
@@ -12,6 +12,7 @@ import CustomText from "../../components/CustomText";
 import { useToast } from "react-native-toast-notifications";
 import CircleIcon from "../../components/CircleIcon";
 import { AntDesign, Entypo, Ionicons } from "@expo/vector-icons";
+import { lightTheme } from "../../theme";
 
 const HeaderView = styled.View`
   align-items: center;
@@ -27,7 +28,7 @@ const ContentItem = styled.View<{ error?: boolean }>`
   width: 100%;
   flex: 1;
   border-bottom-width: 1px;
-  border-bottom-color: ${(props: any) => (props.error ? "#FF6534" : "#cecece")};
+  border-bottom-color: ${(props: any) => (props.error ? props.theme.accentColor : "#cecece")};
   margin: 10px 0px;
 `;
 
@@ -68,7 +69,7 @@ const ValidationItem = styled.View`
 
 const ValidationText = styled.Text`
   font-family: ${(props: any) => props.theme.koreanFontR};
-  color: #ff6534;
+  color: ${(props: any) => props.theme.accentColor};
   font-size: 10px;
 `;
 
@@ -247,7 +248,7 @@ const AccountEdit: React.FC<NativeStackScreenProps<any, "AccountEdit">> = ({ rou
             <ValidationView>
               {specialChar.test(name) ? (
                 <ValidationItem>
-                  <AntDesign name="check" size={12} color={"#ff6534"} />
+                  <AntDesign name="check" size={12} color={lightTheme.accentColor} />
                   <ValidationText>{` 특수문자 불가능`}</ValidationText>
                 </ValidationItem>
               ) : (
@@ -261,7 +262,7 @@ const AccountEdit: React.FC<NativeStackScreenProps<any, "AccountEdit">> = ({ rou
                   <Ionicons
                     name={sex === "M" ? "radio-button-on" : "radio-button-off"}
                     size={16}
-                    color={sex !== "M" || !shouldSelectSex ? "rgba(0, 0, 0, 0.3)" : "#FF6534"}
+                    color={sex !== "M" || !shouldSelectSex ? "rgba(0, 0, 0, 0.3)" : lightTheme.accentColor}
                     style={{ marginRight: 5 }}
                   />
                   <ItemText disabled={!shouldSelectSex}>{`남`}</ItemText>
@@ -270,7 +271,7 @@ const AccountEdit: React.FC<NativeStackScreenProps<any, "AccountEdit">> = ({ rou
                   <Ionicons
                     name={sex === "F" ? "radio-button-on" : "radio-button-off"}
                     size={16}
-                    color={sex !== "F" || !shouldSelectSex ? "rgba(0, 0, 0, 0.3)" : "#FF6534"}
+                    color={sex !== "F" || !shouldSelectSex ? "rgba(0, 0, 0, 0.3)" : lightTheme.accentColor}
                     style={{ marginRight: 5 }}
                   />
                   <ItemText disabled={!shouldSelectSex}>{`여`}</ItemText>

--- a/screens/Preferences/Activity/MyClubs.tsx
+++ b/screens/Preferences/Activity/MyClubs.tsx
@@ -5,7 +5,6 @@ import { ActivityIndicator, Alert, DeviceEventEmitter, FlatList, Platform, Statu
 import { useMutation, useQuery } from "react-query";
 import { UserApi, Club, MyClubsResponse, ErrorResponse, BaseResponse, ClubWithdrawRequest, ClubApi } from "../../../api";
 import CircleIcon from "../../../components/CircleIcon";
-import CustomText from "../../../components/CustomText";
 import { useToast } from "react-native-toast-notifications";
 import { Entypo } from "@expo/vector-icons";
 import Tag from "../../../components/Tag";

--- a/screens/Preferences/Activity/MyClubs.tsx
+++ b/screens/Preferences/Activity/MyClubs.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback, useLayoutEffect, useState } from "react";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import styled from "styled-components/native";
-import { ActivityIndicator, FlatList, Platform, StatusBar, TouchableOpacity, useWindowDimensions } from "react-native";
-import { useQuery } from "react-query";
-import { UserApi, Club, MyClubsResponse, ErrorResponse } from "../../../api";
+import { ActivityIndicator, Alert, DeviceEventEmitter, FlatList, Platform, StatusBar, TouchableOpacity, useWindowDimensions } from "react-native";
+import { useMutation, useQuery } from "react-query";
+import { UserApi, Club, MyClubsResponse, ErrorResponse, BaseResponse, ClubWithdrawRequest, ClubApi } from "../../../api";
 import CircleIcon from "../../../components/CircleIcon";
 import CustomText from "../../../components/CustomText";
 import { useToast } from "react-native-toast-notifications";
@@ -15,15 +15,7 @@ const Loader = styled.SafeAreaView`
   justify-content: center;
   align-items: center;
   padding-top: ${Platform.OS === "android" ? StatusBar.currentHeight : 0}px;
-`;
-
-const Header = styled.View`
   background-color: white;
-  padding: 10px 20px;
-`;
-
-const Title = styled(CustomText)`
-  color: #b0b0b0;
 `;
 
 const Break = styled.View`
@@ -31,16 +23,32 @@ const Break = styled.View`
   border-bottom-color: #e9e9e9;
 `;
 
-const Item = styled.TouchableOpacity`
+const Item = styled.View`
   flex-direction: row;
   width: 100%;
+  justify-content: space-between;
   align-items: center;
   background-color: white;
   padding: 8px 20px;
 `;
 
-const ItemInfo = styled.View`
-  padding-left: 10px;
+const ItemInfo = styled.TouchableOpacity`
+  flex-direction: row;
+  align-items: center;
+`;
+
+const ItemInfoDetail = styled.View``;
+
+const WithdrawButton = styled.TouchableOpacity`
+  background-color: ${(props: any) => props.theme.accentColor};
+  border-radius: 8px;
+`;
+
+const WithdrawText = styled.Text`
+  font-family: ${(props: any) => props.theme.koreanFontR};
+  font-size: 12px;
+  padding: 6px 12px;
+  color: white;
 `;
 
 const ClubNameView = styled.View``;
@@ -49,10 +57,10 @@ const CategoryView = styled.View`
   margin-top: 2px;
 `;
 
-const ItemTitle = styled(CustomText)`
-  font-size: 14px;
-  line-height: 20px;
-  font-family: "NotoSansKR-Medium";
+const ItemTitle = styled.Text`
+  font-family: ${(props: any) => props.theme.koreanFontM};
+  color: #2b2b2b;
+  font-size: 16px;
 `;
 
 const EmptyView = styled.View`
@@ -79,9 +87,22 @@ const MyClubs: React.FC<NativeStackScreenProps<any, "MyClubs">> = ({ navigation:
     data: myClubs,
     refetch: myClubRefetch,
   } = useQuery<MyClubsResponse, ErrorResponse>(["getMyClubs"], UserApi.getMyClubs, {
-    onSuccess: (res) => {},
+    onSuccess: (res) => {
+      onRefresh();
+    },
     onError: (error) => {
       console.log(`API ERROR | getMyClubs ${error.code} ${error.status}`);
+      toast.show(`${error.message ?? error.code}`, { type: "warning" });
+    },
+  });
+
+  const withdrawClubMutation = useMutation<BaseResponse, ErrorResponse, ClubWithdrawRequest>(ClubApi.withdrawClub, {
+    onSuccess: (res) => {
+      toast.show(`모임에서 탈퇴하셨습니다.`, { type: "success" });
+      DeviceEventEmitter.emit("ClubRefetch");
+    },
+    onError: (error) => {
+      console.log(`API ERROR | withdrawClub ${error.code} ${error.status}`);
       toast.show(`${error.message ?? error.code}`, { type: "warning" });
     },
   });
@@ -102,6 +123,19 @@ const MyClubs: React.FC<NativeStackScreenProps<any, "MyClubs">> = ({ navigation:
     });
   };
 
+  const withdrawClub = (clubId: number) => {
+    const requestData = { clubId };
+    Alert.alert("모임 탈퇴", "정말로 모임에서 탈퇴하시겠습니까?", [
+      { text: "아니요" },
+      {
+        text: "예",
+        onPress: () => {
+          withdrawClubMutation.mutate(requestData);
+        },
+      },
+    ]);
+  };
+
   useLayoutEffect(() => {
     setOptions({
       headerLeft: () => (
@@ -112,36 +146,33 @@ const MyClubs: React.FC<NativeStackScreenProps<any, "MyClubs">> = ({ navigation:
     });
   }, []);
 
-  const listHeaderComponent = useCallback(
-    () => (
-      <Header>
-        <Title>가입한 모임 리스트</Title>
-      </Header>
-    ),
-    []
-  );
   const itemSeparatorComponent = useCallback(() => <Break />, []);
   const renderItem = useCallback(
     ({ item, index }: { item: Club; index: number }) => (
-      <Item key={index} onPress={() => goToClubStack(item)}>
-        <CircleIcon size={37} uri={item.thumbnail} />
-        <ItemInfo>
-          <ClubNameView>
-            <ItemTitle>{item.name}</ItemTitle>
-          </ClubNameView>
-          <CategoryView>
-            {item.categories?.map((category, index) => (
-              <Tag
-                key={`Category_${index}`}
-                textColor="white"
-                backgroundColor="#C4C4C4"
-                name={category.name}
-                textStyle={{ fontSize: 10 }}
-                contentContainerStyle={{ paddingTop: 1, paddingBottom: 1 }}
-              />
-            ))}
-          </CategoryView>
+      <Item key={index}>
+        <ItemInfo onPress={() => goToClubStack(item)}>
+          <CircleIcon size={35} uri={item.thumbnail} kerning={10} />
+          <ItemInfoDetail>
+            <ClubNameView>
+              <ItemTitle>{item.name}</ItemTitle>
+            </ClubNameView>
+            <CategoryView>
+              {item.categories?.map((category, index) => (
+                <Tag
+                  key={`Category_${index}`}
+                  textColor="white"
+                  backgroundColor="#C4C4C4"
+                  name={category.name}
+                  textStyle={{ fontSize: 10 }}
+                  contentContainerStyle={{ paddingTop: 1, paddingBottom: 1 }}
+                />
+              ))}
+            </CategoryView>
+          </ItemInfoDetail>
         </ItemInfo>
+        <WithdrawButton onPress={() => withdrawClub(item.id)}>
+          <WithdrawText>{`탈퇴`}</WithdrawText>
+        </WithdrawButton>
       </Item>
     ),
     []
@@ -161,14 +192,13 @@ const MyClubs: React.FC<NativeStackScreenProps<any, "MyClubs">> = ({ navigation:
     </Loader>
   ) : (
     <FlatList
-      contentContainerStyle={{ flexGrow: 1 }}
+      contentContainerStyle={{ flexGrow: 1, backgroundColor: "white" }}
       refreshing={refreshing}
       onRefresh={onRefresh}
       keyExtractor={(item: Club, index: number) => String(index)}
       data={myClubs?.data.filter((item) => item.applyStatus === "APPROVED")}
       ItemSeparatorComponent={itemSeparatorComponent}
       ListFooterComponent={myClubs?.data?.length ? itemSeparatorComponent : null}
-      ListHeaderComponent={listHeaderComponent}
       ListEmptyComponent={listEmptyComponent}
       stickyHeaderIndices={[0]}
       renderItem={renderItem}

--- a/screens/Preferences/Others/Info.tsx
+++ b/screens/Preferences/Others/Info.tsx
@@ -1,13 +1,13 @@
 import React, { useLayoutEffect } from "react";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import styled from "styled-components/native";
-import { Entypo, Feather } from "@expo/vector-icons";
-import CustomText from "../../../components/CustomText";
+import { Entypo } from "@expo/vector-icons";
 import * as WebBrowser from "expo-web-browser";
 import { TouchableOpacity } from "react-native";
 
 const Container = styled.SafeAreaView`
   flex: 1;
+  background-color: white;
 `;
 
 const MenuItem = styled.TouchableOpacity`
@@ -18,16 +18,16 @@ const MenuItem = styled.TouchableOpacity`
   align-items: center;
 `;
 
-const MenuItemText = styled(CustomText)`
+const MenuItemText = styled.Text`
+  font-family: ${(props: any) => props.theme.koreanFontM};
   color: #2e2e2e;
-  font-family: "NotoSansKR-Medium";
   font-size: 16px;
   line-height: 22px;
 `;
 
 const TouchMenu = styled.View`
   height: 50px;
-  border-bottom-width: 1px;
+  border-bottom-width: 0.5px;
   border-bottom-color: #dbdbdb;
   justify-content: center;
 `;
@@ -58,7 +58,7 @@ const Info: React.FC<NativeStackScreenProps<any, "Info">> = ({ navigation: { nav
         <MenuItem onPress={() => openWebView("https://thin-helium-f6d.notion.site/cc73961fd43141d5baab97d1003a4cb3")}>
           <MenuItemText>개인정보처리방침</MenuItemText>
           <ChevronBox>
-            <Feather name="chevron-right" color="#CCCCCC" size={22} />
+            <Entypo name="chevron-thin-right" size={20} color="#CFCFCF" />
           </ChevronBox>
         </MenuItem>
       </TouchMenu>
@@ -66,7 +66,7 @@ const Info: React.FC<NativeStackScreenProps<any, "Info">> = ({ navigation: { nav
         <MenuItem onPress={() => openWebView("https://thin-helium-f6d.notion.site/5b292059b0d04e31925af2fd14e8271b")}>
           <MenuItemText>약관</MenuItemText>
           <ChevronBox>
-            <Feather name="chevron-right" color="#CCCCCC" size={22} />
+            <Entypo name="chevron-thin-right" size={20} color="#CFCFCF" />
           </ChevronBox>
         </MenuItem>
       </TouchMenu>

--- a/screens/Preferences/Others/Suggestion.tsx
+++ b/screens/Preferences/Others/Suggestion.tsx
@@ -2,14 +2,15 @@ import React, { useLayoutEffect, useState } from "react";
 import { ActivityIndicator, KeyboardAvoidingView, Platform, StatusBar, TouchableOpacity } from "react-native";
 import CustomText from "../../../components/CustomText";
 import styled from "styled-components/native";
-import CustomTextInput from "../../../components/CustomTextInput";
 import { useMutation } from "react-query";
 import { BaseResponse, ErrorResponse, SuggestionSubmitRequest, UserApi } from "../../../api";
 import { useToast } from "react-native-toast-notifications";
 import { Entypo } from "@expo/vector-icons";
+import { NativeStackScreenProps } from "@react-navigation/native-stack";
 
 const Container = styled.SafeAreaView`
   flex: 1;
+  background-color: white;
 `;
 const MainView = styled.ScrollView`
   height: 100%;
@@ -26,33 +27,36 @@ const MemoInfo = styled.View`
   justify-content: center;
 `;
 
-const InfoText = styled(CustomText)`
+const InfoText = styled.Text`
+  font-family: ${(props: any) => props.theme.koreanFontR};
   font-size: 12px;
   color: #b5b5b5;
+  margin-bottom: 10px;
 `;
 
-const HeaderTitle = styled(CustomText)`
-  font-family: "NotoSansKR-Medium";
+const HeaderTitle = styled.Text`
+  font-family: ${(props: any) => props.theme.koreanFontM};
   font-size: 16px;
   line-height: 21px;
 `;
 
-const HeaderText = styled(CustomText)`
+const HeaderText = styled.Text`
+  font-family: ${(props: any) => props.theme.koreanFontR};
   font-size: 12px;
   color: #b5b5b5;
   margin: 5px 0px;
 `;
 
-const MemoTextInput = styled(CustomTextInput)`
+const MemoTextInput = styled.TextInput`
+  font-family: ${(props: any) => props.theme.koreanFontR};
   width: 100%;
   height: 300px;
   background-color: #f3f3f3;
   font-size: 15px;
-  line-height: 22px;
   padding: 10px;
 `;
 
-const Suggestion = ({ navigation: { navigate, goBack, setOptions } }) => {
+const Suggestion: React.FC<NativeStackScreenProps<any, "Suggestion">> = ({ navigation: { navigate, goBack, setOptions } }) => {
   const [content, setContent] = useState<string>("");
   const maxLength = 1000;
   const toast = useToast();
@@ -88,8 +92,8 @@ const Suggestion = ({ navigation: { navigate, goBack, setOptions } }) => {
         suggestionMutation.isLoading ? (
           <ActivityIndicator />
         ) : (
-          <TouchableOpacity onPress={save}>
-            <CustomText style={{ color: "#2995FA", fontSize: 14, lineHeight: 20 }}>제출</CustomText>
+          <TouchableOpacity onPress={save} disabled={content.trim() === ""}>
+            <CustomText style={{ color: "#2995FA", fontSize: 14, lineHeight: 20, opacity: content.trim() === "" ? 0.3 : 1 }}>제출</CustomText>
           </TouchableOpacity>
         ),
     });

--- a/screens/Preferences/Others/SuggestionSuccess.tsx
+++ b/screens/Preferences/Others/SuggestionSuccess.tsx
@@ -3,20 +3,21 @@ import { Entypo } from "@expo/vector-icons";
 import { useLayoutEffect } from "react";
 import { StatusBar, TouchableOpacity } from "react-native";
 import styled from "styled-components/native";
-import CustomText from "../../../components/CustomText";
 import BottomButton from "../../../components/BottomButton";
+import { NativeStackScreenProps } from "@react-navigation/native-stack";
 
 const SCREEN_PADDING_SIZE = 20;
 
 const Container = styled.SafeAreaView`
   flex: 1;
+  background-color: white;
 `;
 const Header = styled.View`
   margin: 15px 0px;
 `;
 
-const HeaderText = styled(CustomText)`
-  font-family: "NotoSansKR-Medium";
+const HeaderText = styled.Text`
+  font-family: ${(props: any) => props.theme.koreanFontM};
   font-size: 16px;
   line-height: 21px;
 `;
@@ -26,14 +27,15 @@ const MessageView = styled.ScrollView`
   border: 1px solid #dcdcdc;
 `;
 
-const ContentText = styled(CustomText)`
+const ContentText = styled.Text`
+  font-family: ${(props: any) => props.theme.koreanFontR};
   margin: 8px;
   color: #343434;
   font-size: 14px;
   line-height: 20px;
 `;
 
-const SuggestionSuccess = ({
+const SuggestionSuccess: React.FC<NativeStackScreenProps<any, "SuggestionSuccess">> = ({
   route: {
     params: { content },
   },
@@ -60,7 +62,7 @@ const SuggestionSuccess = ({
           <ContentText>{content}</ContentText>
         </MessageView>
       </Content>
-      <BottomButton title={`마이페이지로 돌아가기`} onPress={() => navigate("Profile")} backgroundColor={"#FF6534"} />
+      <BottomButton title={`마이페이지로 돌아가기`} onPress={() => navigate("Profile")} />
     </Container>
   );
 };

--- a/screens/Preferences/Preferences.tsx
+++ b/screens/Preferences/Preferences.tsx
@@ -4,10 +4,9 @@ import styled from "styled-components/native";
 import { useSelector } from "react-redux";
 import { useQuery } from "react-query";
 import { ErrorResponse, UserApi, UserInfoResponse } from "../../api";
-import { MaterialCommunityIcons, Feather, MaterialIcons, Entypo } from "@expo/vector-icons";
-import { DeviceEventEmitter, StatusBar, TouchableOpacity } from "react-native";
+import { Entypo } from "@expo/vector-icons";
+import { DeviceEventEmitter, StatusBar, TouchableOpacity, View } from "react-native";
 import { useToast } from "react-native-toast-notifications";
-import CustomText from "../../components/CustomText";
 import CircleIcon from "../../components/CircleIcon";
 import { RootState } from "../../redux/store/reducers";
 import { useAppDispatch } from "../../redux/store";
@@ -15,64 +14,61 @@ import { updateUser } from "../../redux/slices/auth";
 
 const Container = styled.SafeAreaView`
   flex: 1;
+  background-color: white;
 `;
-const UserInfoSection = styled.View`
-  background-color: #fff;
-  box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.1);
-  border-bottom-width: 1px;
-  border-bottom-color: #dbdbdb;
-  padding: 0px 20px;
-  height: 100px;
+const Header = styled.TouchableOpacity`
+  margin: 10px 20px;
+  padding: 18px;
+  background-color: #f5f5f5;
+  border-radius: 20px;
   flex-direction: row;
   align-items: center;
-  elevation: 10;
 `;
 
-const InfoBox = styled.View`
+const UserInfo = styled.View`
   align-items: flex-start;
   justify-content: center;
 `;
 
-const Title = styled(CustomText)`
-  font-family: "NotoSansKR-Medium";
+const UserInfoName = styled.Text`
+  font-family: ${(props: any) => props.theme.koreanFontB};
   font-size: 18px;
   line-height: 24px;
 `;
 
-const Email = styled(CustomText)`
+const UserInfoEmail = styled.Text`
+  font-family: ${(props: any) => props.theme.koreanFontR};
   font-size: 14px;
-  line-height: 18px;
-  color: #878787;
-  margin-top: 3px;
-  margin-bottom: 5px;
   line-height: 20px;
+  color: #7d7d7d;
 `;
 
-const MenuWrapper = styled.View`
-  margin-top: 3px;
+const Content = styled.View`
+  padding: 20px;
 `;
 
-const MenuItem = styled.TouchableOpacity`
+const MenuBundle = styled.View`
+  margin-bottom: 15px;
+`;
+
+const MenuBundleTitle = styled.Text`
+  font-family: ${(props: any) => props.theme.koreanFontB};
+  font-size: 14px;
+  line-height: 20px;
+  color: #8e8e8e;
+  margin-bottom: 13px;
+`;
+
+const MenuButton = styled.TouchableOpacity`
   flex-direction: row;
+  justify-content: space-between;
   align-items: center;
-  padding: 10px 17px 10px 20px;
-  justify-content: center;
-  align-items: center;
+  margin-bottom: 13px;
 `;
-
-const MenuItemText = styled(CustomText)`
-  color: #2e2e2e;
-  font-family: "NotoSansKR-Medium";
+const MenuTitle = styled.Text`
+  font-family: ${(props: any) => props.theme.koreanFontM};
   font-size: 16px;
-  line-height: 22px;
-  margin-left: 10px;
-`;
-
-const TouchMenu = styled.View`
-  height: 50px;
-  border-bottom-width: 1px;
-  border-bottom-color: #dbdbdb;
-  justify-content: center;
+  line-height: 17px;
 `;
 
 const LogoutButton = styled.TouchableOpacity`
@@ -86,16 +82,12 @@ const LogoutButton = styled.TouchableOpacity`
   background-color: #000;
 `;
 
-const LogoutText = styled(CustomText)`
+const LogoutText = styled.Text`
+  font-family: ${(props: any) => props.theme.koreanFontM};
   text-align: center;
   font-size: 15px;
   line-height: 22px;
-  color: #fff;
-`;
-
-const ChevronBox = styled.View`
-  flex: 1;
-  align-items: flex-end;
+  color: white;
 `;
 
 const EditBox = styled.View`
@@ -107,8 +99,12 @@ const EditBox = styled.View`
 
 const EditButton = styled.TouchableWithoutFeedback``;
 
+interface ProfileEditBundle {
+  title: string;
+  items: ProfileEditItem[];
+}
+
 interface ProfileEditItem {
-  icon: React.ReactNode;
   title: string;
   screen?: string;
   onPress?: () => void;
@@ -119,7 +115,6 @@ const Preferences: React.FC<NativeStackScreenProps<any, "Preferences">> = ({ nav
   const fcmToken = useSelector((state: RootState) => state.auth.fcmToken);
   const dispatch = useAppDispatch();
   const toast = useToast();
-  const iconSize = 18;
   const {
     isLoading: userInfoLoading, // true or false
     refetch: userInfoRefetch,
@@ -158,71 +153,79 @@ const Preferences: React.FC<NativeStackScreenProps<any, "Preferences">> = ({ nav
     if (screen) navigate("ProfileStack", { screen });
   };
 
-  const goToEditProfile = () => {
+  const goToAccountEdit = () => {
     navigate("ProfileStack", {
-      screen: "EditProfile",
+      screen: "AccountEdit",
       params: userInfo?.data,
     });
   };
 
-  const items: ProfileEditItem[] = [
+  const itemBundle: ProfileEditBundle[] = [
     {
-      icon: <MaterialIcons name="lock" color="#2E2E2E" size={iconSize} />,
-      title: "계정",
-      screen: "AccountSetting",
+      title: "나의 활동",
+      items: [
+        {
+          title: "나의 모임",
+          screen: "MyClubs",
+        },
+      ],
     },
     {
-      icon: <MaterialIcons name="star" color="#2E2E2E" size={iconSize} />,
-      title: "나의 모임",
-      screen: "MyClubs",
+      title: "설정",
+      items: [
+        {
+          title: "계정",
+          screen: "AccountSetting",
+        },
+        {
+          title: "알림 설정",
+          screen: "NotificationSetting",
+        },
+      ],
     },
     {
-      icon: <MaterialIcons name="notifications" size={iconSize} color="#2E2E2E" />,
-      title: "알림 설정",
-      screen: "NotificationSetting",
-    },
-    {
-      icon: <MaterialIcons name="textsms" color="#2E2E2E" size={iconSize} />,
-      title: "건의사항 요청",
-      screen: "Suggestion",
-    },
-    {
-      icon: <MaterialIcons name="info" color="#2E2E2E" size={iconSize} />,
-      title: "정보",
-      screen: "Info",
+      title: "기타",
+      items: [
+        {
+          title: "건의사항 요청",
+          screen: "Suggestion",
+        },
+        {
+          title: "정보",
+          screen: "Info",
+        },
+      ],
     },
   ];
 
   return (
     <Container>
       <StatusBar backgroundColor={"white"} barStyle={"dark-content"} />
-      <UserInfoSection>
-        <CircleIcon size={65} uri={userInfo?.data?.thumbnail} kerning={15} />
-        <InfoBox>
-          <Email>{userInfo?.data?.email}</Email>
-          <Title>{userInfo?.data?.name}</Title>
-        </InfoBox>
+      <Header onPress={goToAccountEdit}>
+        <CircleIcon size={55} uri={userInfo?.data?.thumbnail} kerning={15} />
+        <UserInfo>
+          <UserInfoName>{userInfo?.data?.name}</UserInfoName>
+          <UserInfoEmail>{userInfo?.data?.email}</UserInfoEmail>
+        </UserInfo>
         <EditBox>
-          <EditButton onPress={goToEditProfile}>
-            <MaterialCommunityIcons name="pencil-outline" color="#295AF5" size={20} />
-          </EditButton>
+          <Entypo name="chevron-thin-right" size={20} color="#CFCFCF" />
         </EditBox>
-      </UserInfoSection>
-      <MenuWrapper>
-        {items?.map((item: ProfileEditItem, index: number) => (
-          <TouchMenu key={index}>
-            <MenuItem onPress={() => goToScreen(item.screen)}>
-              {item.icon}
-              <MenuItemText>{item.title}</MenuItemText>
-              <ChevronBox>
-                <Feather name="chevron-right" color="#CCCCCC" size={22} />
-              </ChevronBox>
-            </MenuItem>
-          </TouchMenu>
+      </Header>
+      <Content>
+        {itemBundle?.map((bundle: ProfileEditBundle, index: number) => (
+          <MenuBundle key={`Bundle_${index}`}>
+            <MenuBundleTitle>{bundle.title}</MenuBundleTitle>
+            {bundle.items.map((item: ProfileEditItem, index: number) => (
+              <MenuButton key={`Item_${index}`} onPress={() => goToScreen(item.screen)}>
+                <MenuTitle>{item.title}</MenuTitle>
+                <Entypo name="chevron-thin-right" size={20} color="#CFCFCF" />
+              </MenuButton>
+            ))}
+          </MenuBundle>
         ))}
-      </MenuWrapper>
+      </Content>
       <LogoutButton onPress={goLogout}>
-        <LogoutText>Logout</LogoutText>
+        <LogoutText>{`로그아웃`}</LogoutText>
       </LogoutButton>
     </Container>
   );

--- a/screens/Preferences/Preferences.tsx
+++ b/screens/Preferences/Preferences.tsx
@@ -5,7 +5,7 @@ import { useSelector } from "react-redux";
 import { useQuery } from "react-query";
 import { ErrorResponse, UserApi, UserInfoResponse } from "../../api";
 import { Entypo } from "@expo/vector-icons";
-import { DeviceEventEmitter, StatusBar, TouchableOpacity, View } from "react-native";
+import { DeviceEventEmitter, StatusBar, TouchableOpacity } from "react-native";
 import { useToast } from "react-native-toast-notifications";
 import CircleIcon from "../../components/CircleIcon";
 import { RootState } from "../../redux/store/reducers";

--- a/screens/Preferences/Settings/AccountSetting.tsx
+++ b/screens/Preferences/Settings/AccountSetting.tsx
@@ -5,7 +5,6 @@ import { useSelector } from "react-redux";
 import { useMutation } from "react-query";
 import { Entypo, Feather } from "@expo/vector-icons";
 import { useToast } from "react-native-toast-notifications";
-import CustomText from "../../../components/CustomText";
 import { RootState } from "../../../redux/store/reducers";
 import { BaseResponse, ErrorResponse, UserApi } from "../../../api";
 import { Alert, DeviceEventEmitter, TouchableOpacity } from "react-native";
@@ -14,6 +13,7 @@ import { useAppDispatch } from "../../../redux/store";
 
 const Container = styled.SafeAreaView`
   flex: 1;
+  background-color: white;
 `;
 
 const MenuItem = styled.TouchableOpacity`
@@ -24,16 +24,16 @@ const MenuItem = styled.TouchableOpacity`
   align-items: center;
 `;
 
-const MenuItemText = styled(CustomText)`
+const MenuItemText = styled.Text`
+  font-family: ${(props: any) => props.theme.koreanFontM};
   color: #2e2e2e;
-  font-family: "NotoSansKR-Medium";
   font-size: 16px;
   line-height: 22px;
 `;
 
 const TouchMenu = styled.View`
   height: 50px;
-  border-bottom-width: 1px;
+  border-bottom-width: 0.5px;
   border-bottom-color: #dbdbdb;
   justify-content: center;
 `;
@@ -82,7 +82,7 @@ const AccountSetting: React.FC<NativeStackScreenProps<any, "AccountSetting">> = 
   const withdrawUser = () => {
     Alert.alert(
       "탈퇴",
-      "탈퇴 후 계정 복구는 불가합니다. 정말로 탈퇴하시겠습니까?",
+      "탈퇴 후 계정 복구는 불가합니다.\n정말로 탈퇴하시겠습니까?",
       [
         {
           text: "네",
@@ -103,7 +103,7 @@ const AccountSetting: React.FC<NativeStackScreenProps<any, "AccountSetting">> = 
       onPress: () => goToScreen("ChangePassword"),
     },
     {
-      title: "차단된 계정",
+      title: "차단 계정 관리",
       onPress: () => goToScreen("BlockUserList"),
     },
     {
@@ -119,7 +119,7 @@ const AccountSetting: React.FC<NativeStackScreenProps<any, "AccountSetting">> = 
           <MenuItem onPress={item.onPress}>
             <MenuItemText>{item.title}</MenuItemText>
             <ChevronBox>
-              <Feather name="chevron-right" color="#CCCCCC" size={22} />
+              <Entypo name="chevron-thin-right" size={20} color="#CFCFCF" />
             </ChevronBox>
           </MenuItem>
         </TouchMenu>

--- a/screens/Preferences/Settings/BlockUserList.tsx
+++ b/screens/Preferences/Settings/BlockUserList.tsx
@@ -11,7 +11,7 @@ import CustomText from "../../../components/CustomText";
 
 const Container = styled.SafeAreaView`
   flex: 1;
-  padding-top: ${Platform.OS === "android" ? StatusBar.currentHeight : 0}px;
+  background-color: white;
 `;
 
 const Item = styled.View`
@@ -23,7 +23,7 @@ const Item = styled.View`
   padding: 8px 20px;
 `;
 
-const ItemLeft = styled.View`
+const UserInfo = styled.TouchableOpacity`
   flex-direction: row;
   align-items: center;
 `;
@@ -34,25 +34,27 @@ const ItemLeftDetail = styled.View`
   padding-left: 10px;
 `;
 
-const ItemText = styled(CustomText)`
+const ItemText = styled.Text`
+  font-family: ${(props: any) => props.theme.koreanFontM};
   font-size: 16px;
-  line-height: 21px;
-  font-family: "NotoSansKR-Medium";
+  line-height: 17px;
   /* margin-bottom: 2px; */
 `;
 
 const UnblockButton = styled.TouchableOpacity`
-  background-color: #ff6534;
+  background-color: ${(props: any) => props.theme.accentColor};
   border-radius: 8px;
 `;
 
-const UnBlockButtonText = styled(CustomText)`
-  padding: 5px 12px;
+const UnBlockButtonText = styled.Text`
+  font-family: ${(props: any) => props.theme.koreanFontR};
+  font-size: 12px;
+  padding: 6px 12px;
   color: white;
 `;
 
 const Break = styled.View`
-  border-bottom-width: 1px;
+  border-bottom-width: 0.5px;
   border-bottom-color: #e9e9e9;
 `;
 
@@ -90,7 +92,7 @@ const BlockUserList: React.FC<NativeStackScreenProps<any, "BlockUserList">> = ({
   const unblockMutation = useMutation<BaseResponse, ErrorResponse, UserBlockRequest>(UserApi.blockUser, {
     onSuccess: (res) => {
       toast.show(`차단을 해제했습니다.`, { type: "success" });
-      blockUserListRefetch();
+      onRefresh();
     },
     onError: (error) => {
       console.log(`API ERROR | blockUser ${error.code} ${error.status}`);
@@ -118,6 +120,8 @@ const BlockUserList: React.FC<NativeStackScreenProps<any, "BlockUserList">> = ({
     ]);
   };
 
+  const goToProfile = (userId?: number) => navigate("ProfileStack", { screen: "Profile", params: { userId } });
+
   useEffect(() => {
     setOptions({
       headerLeft: () => (
@@ -132,12 +136,12 @@ const BlockUserList: React.FC<NativeStackScreenProps<any, "BlockUserList">> = ({
   const renderItem = useCallback(
     ({ item, index }: { item: BlockUser; index: number }) => (
       <Item key={index}>
-        <ItemLeft>
-          <CircleIcon size={46} uri={item.thumbnail} />
+        <UserInfo onPress={() => goToProfile(item.userId)}>
+          <CircleIcon size={40} uri={item.thumbnail} />
           <ItemLeftDetail>
             <ItemText>{item.userName}</ItemText>
           </ItemLeftDetail>
-        </ItemLeft>
+        </UserInfo>
         <ItemRight>
           <UnblockButton onPress={() => unblock(item.userName, item.userId)}>
             <UnBlockButtonText>{`차단 해제`}</UnBlockButtonText>
@@ -163,7 +167,7 @@ const BlockUserList: React.FC<NativeStackScreenProps<any, "BlockUserList">> = ({
     </Container>
   ) : (
     <FlatList
-      contentContainerStyle={{ flexGrow: 1, paddingVertical: 5 }}
+      contentContainerStyle={{ flexGrow: 1, paddingVertical: 5, backgroundColor: "white" }}
       refreshing={refreshing}
       onRefresh={onRefresh}
       keyExtractor={(item: BlockUser, index: number) => String(index)}

--- a/screens/Preferences/Settings/BlockUserList.tsx
+++ b/screens/Preferences/Settings/BlockUserList.tsx
@@ -1,13 +1,12 @@
 import { Entypo } from "@expo/vector-icons";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import React, { useCallback, useEffect, useState } from "react";
-import { ActivityIndicator, Alert, FlatList, Platform, StatusBar, TouchableOpacity } from "react-native";
+import { ActivityIndicator, Alert, FlatList, TouchableOpacity } from "react-native";
 import { useToast } from "react-native-toast-notifications";
 import { useMutation, useQuery } from "react-query";
 import styled from "styled-components/native";
 import { BaseResponse, BlockUser, BlockUserListResponse, ErrorResponse, UserApi, UserBlockRequest } from "../../../api";
 import CircleIcon from "../../../components/CircleIcon";
-import CustomText from "../../../components/CustomText";
 
 const Container = styled.SafeAreaView`
   flex: 1;

--- a/screens/Preferences/Settings/ChangePassword.tsx
+++ b/screens/Preferences/Settings/ChangePassword.tsx
@@ -8,6 +8,7 @@ import { useToast } from "react-native-toast-notifications";
 import { UserApi, BaseResponse, ErrorResponse, PasswordChangeRequest } from "../../../api";
 import { AntDesign, Entypo } from "@expo/vector-icons";
 import BottomButton from "../../../components/BottomButton";
+import { lightTheme } from "../../../theme";
 
 const Container = styled.View`
   flex: 1;
@@ -22,7 +23,7 @@ const Item = styled.View`
 const ItemText = styled.Text`
   font-family: ${(props: any) => props.theme.koreanFontSB};
   font-size: 16px;
-  color: #aeaeae;
+  color: ${(props: any) => props.theme.infoColor};
   margin-bottom: 10px;
 `;
 
@@ -117,19 +118,19 @@ const ChangePassword: React.FC<NativeStackScreenProps<any, "ChangePassword">> = 
 
             <ValidationView>
               <ValidationItem>
-                <AntDesign name="check" size={12} color={engReg.test(password) ? "#6B8BF7" : "#8e8e8e"} />
+                <AntDesign name="check" size={12} color={engReg.test(password) ? lightTheme.primaryColor : "#8e8e8e"} />
                 <ValidationText>{` 영문 포함`}</ValidationText>
               </ValidationItem>
               <ValidationItem>
-                <AntDesign name="check" size={12} color={numReg.test(password) ? "#6B8BF7" : "#8e8e8e"} />
+                <AntDesign name="check" size={12} color={numReg.test(password) ? lightTheme.primaryColor : "#8e8e8e"} />
                 <ValidationText>{` 숫자 포함`}</ValidationText>
               </ValidationItem>
               <ValidationItem>
-                <AntDesign name="check" size={12} color={specialReg.test(password) ? "#6B8BF7" : "#8e8e8e"} />
+                <AntDesign name="check" size={12} color={specialReg.test(password) ? lightTheme.primaryColor : "#8e8e8e"} />
                 <ValidationText>{` 특수문자 포함`}</ValidationText>
               </ValidationItem>
               <ValidationItem>
-                <AntDesign name="check" size={12} color={password.length > 7 ? "#6B8BF7" : "#8e8e8e"} />
+                <AntDesign name="check" size={12} color={password.length > 7 ? lightTheme.primaryColor : "#8e8e8e"} />
                 <ValidationText>{` 8자리 이상`}</ValidationText>
               </ValidationItem>
             </ValidationView>
@@ -147,7 +148,7 @@ const ChangePassword: React.FC<NativeStackScreenProps<any, "ChangePassword">> = 
             />
             {password !== checkPassword && password !== "" && checkPassword !== "" ? (
               <ValidationView>
-                <AntDesign name="exclamationcircleo" size={12} color="#EC5D56" />
+                <AntDesign name="exclamationcircleo" size={12} color={lightTheme.accentColor} />
                 <ErrorText>{` 입력을 다시 한번 확인해주세요.`}</ErrorText>
               </ValidationView>
             ) : (

--- a/screens/Preferences/Settings/ChangePassword.tsx
+++ b/screens/Preferences/Settings/ChangePassword.tsx
@@ -1,39 +1,43 @@
 import React, { useState, useEffect } from "react";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import styled from "styled-components/native";
-import { TouchableOpacity, StatusBar, ActivityIndicator } from "react-native";
+import { TouchableOpacity, StatusBar } from "react-native";
 import { Keyboard, TouchableWithoutFeedback } from "react-native";
 import { useMutation } from "react-query";
-import CustomText from "../../../components/CustomText";
 import { useToast } from "react-native-toast-notifications";
-import CustomTextInput from "../../../components/CustomTextInput";
 import { UserApi, BaseResponse, ErrorResponse, PasswordChangeRequest } from "../../../api";
 import { AntDesign, Entypo } from "@expo/vector-icons";
+import BottomButton from "../../../components/BottomButton";
 
 const Container = styled.View`
   flex: 1;
   padding: 20px 20px;
+  background-color: white;
 `;
 
 const Item = styled.View`
   margin-bottom: 30px;
 `;
 
-const ItemText = styled(CustomText)`
-  color: #8e8e8e;
+const ItemText = styled.Text`
+  font-family: ${(props: any) => props.theme.koreanFontSB};
+  font-size: 16px;
+  color: #aeaeae;
   margin-bottom: 10px;
 `;
 
-const Input = styled(CustomTextInput)<{ error: boolean }>`
-  font-size: 16px;
-  line-height: 21px;
+const Input = styled.TextInput<{ error: boolean }>`
+  font-family: ${(props: any) => props.theme.koreanFontR};
+  font-size: 20px;
   border-bottom-width: 1px;
-  border-bottom-color: ${(props: any) => (props.error ? "#ff6534" : "#b3b3b3")};
+  border-bottom-color: ${(props: any) => (props.error ? props.theme.accentColor : "#b3b3b3")};
 `;
 
-const ErrorText = styled(CustomText)`
-  color: #ff6534;
+const ErrorText = styled.Text`
+  font-family: ${(props: any) => props.theme.koreanFontR};
+  color: ${(props: any) => props.theme.accentColor};
   font-size: 12px;
+  line-height: 14px;
 `;
 
 const ValidationView = styled.View`
@@ -49,8 +53,10 @@ const ValidationItem = styled.View`
 `;
 
 const ValidationText = styled.Text`
+  font-family: ${(props: any) => props.theme.englishFontL};
   color: #8e8e8e;
   font-size: 10px;
+  line-height: 14px;
 `;
 
 const ChangePassword: React.FC<NativeStackScreenProps<any, "ChangePassword">> = ({ navigation: { navigate, setOptions, goBack } }) => {
@@ -80,25 +86,8 @@ const ChangePassword: React.FC<NativeStackScreenProps<any, "ChangePassword">> = 
           <Entypo name="chevron-thin-left" size={20} color="black" />
         </TouchableOpacity>
       ),
-      headerRight: () =>
-        mutation.isLoading ? (
-          <ActivityIndicator />
-        ) : (
-          <TouchableOpacity onPress={onSubmit} disabled={!numReg.test(password) || !engReg.test(password) || !specialReg.test(password) || password !== checkPassword || password.length < 8}>
-            <CustomText
-              style={{
-                color: "#2995FA",
-                fontSize: 14,
-                lineHeight: 20,
-                opacity: !numReg.test(password) || !engReg.test(password) || !specialReg.test(password) || password !== checkPassword || password.length < 8 ? 0.3 : 1,
-              }}
-            >
-              저장
-            </CustomText>
-          </TouchableOpacity>
-        ),
     });
-  }, [password, checkPassword, mutation.isLoading]);
+  }, []);
 
   const onSubmit = () => {
     if (password.length < 8) return toast.show(`변경불가: 8자리 이상이어야 합니다.`, { type: "danger" });
@@ -111,61 +100,68 @@ const ChangePassword: React.FC<NativeStackScreenProps<any, "ChangePassword">> = 
   };
 
   return (
-    <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
-      <Container>
-        <StatusBar backgroundColor={"white"} barStyle={"dark-content"} />
-        <Item>
-          <ItemText>{`비밀번호 재설정`}</ItemText>
-          <Input
-            placeholder="영문, 숫자, 특수문자 포함 8자 이상"
-            placeholderTextColor={"#B0B0B0"}
-            secureTextEntry={true}
-            autoCorrect={false}
-            onChangeText={(value: string) => setPassword(value)}
-            includeFontPadding={false}
-          />
+    <>
+      <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+        <Container>
+          <StatusBar backgroundColor={"white"} barStyle={"dark-content"} />
+          <Item>
+            <ItemText>{`비밀번호 재설정`}</ItemText>
+            <Input
+              placeholder="영문, 숫자, 특수문자 포함 8자 이상"
+              placeholderTextColor={"#B0B0B0"}
+              secureTextEntry={true}
+              autoCorrect={false}
+              onChangeText={(value: string) => setPassword(value)}
+              includeFontPadding={false}
+            />
 
-          <ValidationView>
-            <ValidationItem>
-              <AntDesign name="check" size={12} color={engReg.test(password) ? "#295AF5" : "#8e8e8e"} />
-              <ValidationText>{` 영문 포함`}</ValidationText>
-            </ValidationItem>
-            <ValidationItem>
-              <AntDesign name="check" size={12} color={numReg.test(password) ? "#295AF5" : "#8e8e8e"} />
-              <ValidationText>{` 숫자 포함`}</ValidationText>
-            </ValidationItem>
-            <ValidationItem>
-              <AntDesign name="check" size={12} color={specialReg.test(password) ? "#295AF5" : "#8e8e8e"} />
-              <ValidationText>{` 특수문자 포함`}</ValidationText>
-            </ValidationItem>
-            <ValidationItem>
-              <AntDesign name="check" size={12} color={password.length > 7 ? "#295AF5" : "#8e8e8e"} />
-              <ValidationText>{` 8자리 이상`}</ValidationText>
-            </ValidationItem>
-          </ValidationView>
-        </Item>
-        <Item>
-          <ItemText>{`비밀번호 재입력`}</ItemText>
-          <Input
-            placeholder="영문, 숫자, 특수문자 포함 8자 이상"
-            placeholderTextColor={"#B0B0B0"}
-            secureTextEntry={true}
-            autoCorrect={false}
-            onChangeText={(value: string) => setCheckPassword(value)}
-            includeFontPadding={false}
-            error={password !== checkPassword && password !== "" && checkPassword !== ""}
-          />
-          {password !== checkPassword && password !== "" && checkPassword !== "" ? (
             <ValidationView>
-              <AntDesign name="exclamationcircleo" size={12} color="#ff6534" />
-              <ErrorText>{` 입력을 다시 한번 확인해주세요.`}</ErrorText>
+              <ValidationItem>
+                <AntDesign name="check" size={12} color={engReg.test(password) ? "#6B8BF7" : "#8e8e8e"} />
+                <ValidationText>{` 영문 포함`}</ValidationText>
+              </ValidationItem>
+              <ValidationItem>
+                <AntDesign name="check" size={12} color={numReg.test(password) ? "#6B8BF7" : "#8e8e8e"} />
+                <ValidationText>{` 숫자 포함`}</ValidationText>
+              </ValidationItem>
+              <ValidationItem>
+                <AntDesign name="check" size={12} color={specialReg.test(password) ? "#6B8BF7" : "#8e8e8e"} />
+                <ValidationText>{` 특수문자 포함`}</ValidationText>
+              </ValidationItem>
+              <ValidationItem>
+                <AntDesign name="check" size={12} color={password.length > 7 ? "#6B8BF7" : "#8e8e8e"} />
+                <ValidationText>{` 8자리 이상`}</ValidationText>
+              </ValidationItem>
             </ValidationView>
-          ) : (
-            <></>
-          )}
-        </Item>
-      </Container>
-    </TouchableWithoutFeedback>
+          </Item>
+          <Item>
+            <ItemText>{`비밀번호 재입력`}</ItemText>
+            <Input
+              placeholder="영문, 숫자, 특수문자 포함 8자 이상"
+              placeholderTextColor={"#B0B0B0"}
+              secureTextEntry={true}
+              autoCorrect={false}
+              onChangeText={(value: string) => setCheckPassword(value)}
+              includeFontPadding={false}
+              error={password !== checkPassword && password !== "" && checkPassword !== ""}
+            />
+            {password !== checkPassword && password !== "" && checkPassword !== "" ? (
+              <ValidationView>
+                <AntDesign name="exclamationcircleo" size={12} color="#EC5D56" />
+                <ErrorText>{` 입력을 다시 한번 확인해주세요.`}</ErrorText>
+              </ValidationView>
+            ) : (
+              <></>
+            )}
+          </Item>
+        </Container>
+      </TouchableWithoutFeedback>
+      <BottomButton
+        title={"제출"}
+        onPress={onSubmit}
+        disabled={mutation.isLoading || !numReg.test(password) || !engReg.test(password) || !specialReg.test(password) || password !== checkPassword || password.length < 8}
+      />
+    </>
   );
 };
 

--- a/screens/Preferences/Settings/NotificationSetting.tsx
+++ b/screens/Preferences/Settings/NotificationSetting.tsx
@@ -1,11 +1,10 @@
 import { Entypo } from "@expo/vector-icons";
 import React, { useEffect, useLayoutEffect, useState } from "react";
-import { Switch, Platform, TouchableOpacity, ActivityIndicator, PermissionsAndroid, Linking, Alert } from "react-native";
+import { Switch, Platform, TouchableOpacity, ActivityIndicator, Linking, Alert } from "react-native";
 import { useToast } from "react-native-toast-notifications";
 import { useMutation, useQuery } from "react-query";
 import styled from "styled-components/native";
 import { BaseResponse, ErrorResponse, PushAlarmResponse, UserApi, UserPushAlarmRequest } from "../../../api";
-import CustomText from "../../../components/CustomText";
 import messaging from "@react-native-firebase/messaging";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 

--- a/screens/Preferences/Settings/NotificationSetting.tsx
+++ b/screens/Preferences/Settings/NotificationSetting.tsx
@@ -7,6 +7,7 @@ import styled from "styled-components/native";
 import { BaseResponse, ErrorResponse, PushAlarmResponse, UserApi, UserPushAlarmRequest } from "../../../api";
 import messaging from "@react-native-firebase/messaging";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
+import { lightTheme } from "../../../theme";
 
 const Loader = styled.SafeAreaView`
   flex: 1;
@@ -163,7 +164,7 @@ const NotificationSetting: React.FC<NativeStackScreenProps<any, "NotificationSet
           <ItemSub>
             <ItemTitle>{`개인 알람`}</ItemTitle>
             <Switch
-              trackColor={{ false: "#D4D4D4", true: "#6B8BF7" }}
+              trackColor={{ false: "#D4D4D4", true: lightTheme.primaryColor }}
               thumbColor={"white"}
               onValueChange={() => onValueChange("USER")}
               value={userPush}
@@ -176,7 +177,7 @@ const NotificationSetting: React.FC<NativeStackScreenProps<any, "NotificationSet
           <ItemSub>
             <ItemTitle>{`모임 알람`}</ItemTitle>
             <Switch
-              trackColor={{ false: "#D4D4D4", true: "#6B8BF7" }}
+              trackColor={{ false: "#D4D4D4", true: lightTheme.primaryColor }}
               thumbColor={"white"}
               onValueChange={() => onValueChange("CLUB")}
               value={clubPush}

--- a/screens/Preferences/Settings/NotificationSetting.tsx
+++ b/screens/Preferences/Settings/NotificationSetting.tsx
@@ -7,29 +7,33 @@ import styled from "styled-components/native";
 import { BaseResponse, ErrorResponse, PushAlarmResponse, UserApi, UserPushAlarmRequest } from "../../../api";
 import CustomText from "../../../components/CustomText";
 import messaging from "@react-native-firebase/messaging";
+import { NativeStackScreenProps } from "@react-navigation/native-stack";
 
 const Loader = styled.SafeAreaView`
   flex: 1;
+  background-color: white;
 `;
 
 const Container = styled.ScrollView`
   flex: 1;
+  background-color: white;
 `;
 const Header = styled.View`
   padding: 10px 20px;
   margin-top: 3px;
 `;
-const HeaderTitle = styled(CustomText)`
-  font-family: "NotoSansKR-Bold";
+const HeaderTitle = styled.Text`
+  font-family: ${(props: any) => props.theme.koreanFontB};
   font-size: 18px;
   line-height: 22px;
   color: #2b2b2b;
   margin-bottom: 5px;
 `;
 
-const HeaderText = styled(CustomText)`
+const HeaderText = styled.Text`
+  font-family: ${(props: any) => props.theme.koreanFontR};
   font-size: 12px;
-  line-height: 16px;
+  line-height: 18px;
   color: #b0b0b0;
   margin-top: 1px;
 `;
@@ -50,19 +54,20 @@ const ItemSub = styled.View`
   height: 30px;
 `;
 
-const ItemTitle = styled(CustomText)`
+const ItemTitle = styled.Text`
+  font-family: ${(props: any) => props.theme.koreanFontR};
   font-size: 18px;
-  line-height: 28px;
+  line-height: 21px;
   color: #2b2b2b;
-  margin-bottom: 5px;
 `;
 
-const ItemText = styled(CustomText)`
+const ItemText = styled.Text`
+  font-family: ${(props: any) => props.theme.koreanFontR};
   font-size: 12px;
   color: #b0b0b0;
 `;
 
-const NotificationSetting = ({ navigation: { navigate, goBack, setOptions } }) => {
+const NotificationSetting: React.FC<NativeStackScreenProps<any, "NotificationSetting">> = ({ navigation: { navigate, goBack, setOptions } }) => {
   const toast = useToast();
   const [permission, setPermission] = useState<boolean>(false);
   const [userPush, setUserPush] = useState<boolean>(false);
@@ -159,7 +164,7 @@ const NotificationSetting = ({ navigation: { navigate, goBack, setOptions } }) =
           <ItemSub>
             <ItemTitle>{`개인 알람`}</ItemTitle>
             <Switch
-              trackColor={{ false: "#D4D4D4", true: "#FF6534" }}
+              trackColor={{ false: "#D4D4D4", true: "#6B8BF7" }}
               thumbColor={"white"}
               onValueChange={() => onValueChange("USER")}
               value={userPush}
@@ -172,7 +177,7 @@ const NotificationSetting = ({ navigation: { navigate, goBack, setOptions } }) =
           <ItemSub>
             <ItemTitle>{`모임 알람`}</ItemTitle>
             <Switch
-              trackColor={{ false: "#D4D4D4", true: "#FF6534" }}
+              trackColor={{ false: "#D4D4D4", true: "#6B8BF7" }}
               thumbColor={"white"}
               onValueChange={() => onValueChange("CLUB")}
               value={clubPush}

--- a/screens/Profile/Profile.tsx
+++ b/screens/Profile/Profile.tsx
@@ -22,7 +22,6 @@ import { useFocusEffect } from "@react-navigation/native";
 
 const Container = styled.View`
   flex: 1;
-  background-color: orange;
 `;
 
 const HEADER_EXPANDED_HEIGHT = 300;
@@ -167,6 +166,7 @@ const Profile: React.FC<NativeStackScreenProps<any, "Profile">> = ({
   useFocusEffect(() => {
     // Android만 지원
     StatusBar.setTranslucent(true);
+    StatusBar.setBackgroundColor("transparent");
   });
 
   return (

--- a/screens/Profile/Profile.tsx
+++ b/screens/Profile/Profile.tsx
@@ -1,6 +1,6 @@
 import { createMaterialTopTabNavigator } from "@react-navigation/material-top-tabs";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
-import React, { useCallback, useMemo, useRef } from "react";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { View, useWindowDimensions, StatusBar, Animated, Platform } from "react-native";
 import { useModalize } from "react-native-modalize";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -18,9 +18,11 @@ import UserInstroduction from "./UserInstroduction";
 import dynamicLinks from "@react-native-firebase/dynamic-links";
 import Share from "react-native-share";
 import ProfileReportModal from "./ProfileReportModal";
+import { useFocusEffect } from "@react-navigation/native";
 
 const Container = styled.View`
   flex: 1;
+  background-color: orange;
 `;
 
 const HEADER_EXPANDED_HEIGHT = 300;
@@ -162,6 +164,11 @@ const Profile: React.FC<NativeStackScreenProps<any, "Profile">> = ({
     } catch (e) {}
   };
 
+  useFocusEffect(() => {
+    // Android만 지원
+    StatusBar.setTranslucent(true);
+  });
+
   return (
     <Container>
       <StatusBar translucent backgroundColor={"transparent"} barStyle={"dark-content"} />
@@ -187,7 +194,7 @@ const Profile: React.FC<NativeStackScreenProps<any, "Profile">> = ({
           zIndex: 2,
           flex: 1,
           width: "100%",
-          height: SCREEN_HEIGHT + headerDiff,
+          height: SCREEN_HEIGHT + HEADER_EXPANDED_HEIGHT - HEADER_HEIGHT,
           paddingTop: heightExpanded,
           transform: [{ translateY }],
         }}

--- a/screens/Profile/Profile.tsx
+++ b/screens/Profile/Profile.tsx
@@ -19,6 +19,7 @@ import dynamicLinks from "@react-native-firebase/dynamic-links";
 import Share from "react-native-share";
 import ProfileReportModal from "./ProfileReportModal";
 import { useFocusEffect } from "@react-navigation/native";
+import { lightTheme } from "../../theme";
 
 const Container = styled.View`
   flex: 1;
@@ -202,7 +203,7 @@ const Profile: React.FC<NativeStackScreenProps<any, "Profile">> = ({
         <TopTab.Navigator
           initialRouteName="UserInstroduction"
           screenOptions={{ swipeEnabled: false }}
-          tabBar={(props) => <TabBar {...props} height={TAB_BAR_HEIGHT} rounding={true} />}
+          tabBar={(props) => <TabBar {...props} height={TAB_BAR_HEIGHT} rounding={true} focusColor={lightTheme.accentColor} />}
           sceneContainerStyle={{ position: "absolute", zIndex: 1 }}
         >
           <TopTab.Screen options={{ tabBarLabel: "소개" }} name="UserInstroduction" component={renderUserInstroduction} />

--- a/screens/Profile/UserFeed.tsx
+++ b/screens/Profile/UserFeed.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Text } from "react-native";
+import { StatusBar, Text } from "react-native";
 import styled from "styled-components/native";
 
 const Container = styled.SafeAreaView`
@@ -9,6 +9,7 @@ const Container = styled.SafeAreaView`
 const UserFeed = () => {
   return (
     <Container>
+      <StatusBar translucent backgroundColor={"transparent"} barStyle={"dark-content"} />
       <Text>TEST</Text>
     </Container>
   );

--- a/screens/Profile/UserInstroduction.tsx
+++ b/screens/Profile/UserInstroduction.tsx
@@ -1,4 +1,5 @@
 import { useNavigation } from "@react-navigation/native";
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import React from "react";
 import { ActivityIndicator } from "react-native";
 import FastImage from "react-native-fast-image";
@@ -118,8 +119,8 @@ interface UserInstroductionProps {
 }
 
 const UserInstroduction: React.FC<UserInstroductionProps> = ({ profile }) => {
-  const navigation = useNavigation();
-  const goToClub = (clubId: number) => navigation.navigate("ClubStack", { screen: "ClubTopTabs", params: { clubData: { id: clubId } } });
+  const navigation = useNavigation<NativeStackNavigationProp<any>>();
+  const goToClub = (clubId: number) => navigation.push("ClubStack", { screen: "ClubTopTabs", params: { clubData: { id: clubId } } });
   return !profile ? (
     <Loader>
       <ActivityIndicator />

--- a/screens/SignUp/SignUpBirth.tsx
+++ b/screens/SignUp/SignUpBirth.tsx
@@ -30,13 +30,13 @@ const Border = styled.View`
 `;
 
 const AskText = styled.Text`
-  font-family: "AppleSDGothicNeoB";
+  font-family: ${(props: any) => props.theme.koreanFontB};
   font-size: 20px;
   margin-top: 24px;
 `;
 
 const SubText = styled.Text`
-  font-family: "AppleSDGothicNeoR";
+  font-family: ${(props: any) => props.theme.koreanFontR};
   color: #a0a0a0;
   font-size: 13px;
   margin-top: 7px;
@@ -44,7 +44,7 @@ const SubText = styled.Text`
 
 const Input = styled.TextInput`
   border-bottom-width: 1px;
-  border-bottom-color: ${(props: any) => (props.error ? "#E7564F" : "#b3b3b3")};
+  border-bottom-color: ${(props: any) => (props.error ? props.theme.accentColor : "#b3b3b3")};
   margin-top: 47px;
   font-size: 18px;
 `;
@@ -54,7 +54,7 @@ const ErrorView = styled.View`
 `;
 
 const Error = styled.Text`
-  font-family: "AppleSDGothicNeoR";
+  font-family: ${(props: any) => props.theme.koreanFontR};
   color: #e7564f;
   font-size: 12px;
   margin-top: 7px;
@@ -69,7 +69,7 @@ const FieldContentOptionLine = styled.View`
 const SkipButton = styled.TouchableOpacity``;
 
 const SkipText = styled.Text`
-  font-family: "AppleSDGothicNeoR";
+  font-family: ${(props: any) => props.theme.koreanFontR};
   font-size: 12px;
   color: #8e8e8e;
 `;

--- a/screens/SignUp/SignUpChurch.tsx
+++ b/screens/SignUp/SignUpChurch.tsx
@@ -31,13 +31,13 @@ const Border = styled.View`
 `;
 
 const AskText = styled.Text`
-  font-family: "AppleSDGothicNeoB";
+  font-family: ${(props: any) => props.theme.koreanFontB};
   font-size: 20px;
   margin-top: 24px;
 `;
 
 const SubText = styled.Text`
-  font-family: "AppleSDGothicNeoR";
+  font-family: ${(props: any) => props.theme.koreanFontR};
   color: #a0a0a0;
   font-size: 13px;
   margin-top: 7px;
@@ -74,7 +74,7 @@ const ChoiceButton = styled.TouchableOpacity`
 `;
 
 const FieldContentText = styled.Text`
-  font-family: "AppleSDGothicNeoR";
+  font-family: ${(props: any) => props.theme.koreanFontR};
   font-size: 18px;
   margin-right: 10px;
 `;

--- a/screens/SignUp/SignUpConfirm.tsx
+++ b/screens/SignUp/SignUpConfirm.tsx
@@ -23,13 +23,13 @@ const Wrap = styled.View`
 `;
 
 const AskText = styled.Text`
-  font-family: "AppleSDGothicNeoB";
+  font-family: ${(props: any) => props.theme.koreanFontB};
   font-size: 20px;
   margin-top: 24px;
 `;
 
 const SubText = styled.Text`
-  font-family: "AppleSDGothicNeoR";
+  font-family: ${(props: any) => props.theme.koreanFontR};
   color: #a0a0a0;
   font-size: 13px;
   margin-top: 7px;

--- a/screens/SignUp/SignUpEmail.tsx
+++ b/screens/SignUp/SignUpEmail.tsx
@@ -48,32 +48,32 @@ const Border = styled.View`
 `;
 
 const AskText = styled.Text`
-  font-family: "AppleSDGothicNeoB";
+  font-family: ${(props: any) => props.theme.koreanFontB};
   font-size: 20px;
   margin-top: 24px;
 `;
 
 const SubText = styled.Text`
-  font-family: "AppleSDGothicNeoR";
+  font-family: ${(props: any) => props.theme.koreanFontR};
   color: #a0a0a0;
   font-size: 13px;
   margin-top: 7px;
 `;
 
 const ItemText = styled.Text`
-  font-family: "Roboto-Regular";
+  font-family: ${(props: any) => props.theme.englishFontR};
   color: #a0a0a0;
   font-size: 13px;
   margin-bottom: 3px;
 `;
 
 const Input = styled.TextInput<{ error: boolean }>`
-  font-family: "Roboto-Regular";
+  font-family: ${(props: any) => props.theme.englishFontR};
   font-size: 18px;
 `;
 
 const Error = styled.Text`
-  font-family: "AppleSDGothicNeoR";
+  font-family: ${(props: any) => props.theme.koreanFontR};
   color: #e7564f;
   font-size: 12px;
 `;

--- a/screens/SignUp/SignUpEmail.tsx
+++ b/screens/SignUp/SignUpEmail.tsx
@@ -8,6 +8,7 @@ import { useMutation } from "react-query";
 import { CommonApi, DuplicateCheckResponse, EmailCheckRequest, EmailValidRequest, SendCheckEmailResponse, ValidCheckEmailResponse } from "../../api";
 import { useToast } from "react-native-toast-notifications";
 import BottomButton from "../../components/BottomButton";
+import { lightTheme } from "../../theme";
 
 const Container = styled.View`
   width: 100%;
@@ -26,7 +27,7 @@ const Header = styled.View`
 
 const Item = styled.View<{ error: boolean }>`
   border-bottom-width: 1px;
-  border-bottom-color: ${(props: any) => (props.error ? "#ff6534" : "#b3b3b3")};
+  border-bottom-color: ${(props: any) => (props.error ? props.theme.accentColor : "#b3b3b3")};
   margin-bottom: ${(props: any) => (props.error ? 0 : 43)}px;
 `;
 
@@ -216,7 +217,7 @@ const SignUpEmail: React.FC<NativeStackScreenProps<any, "SignUpEmail">> = ({
           </Item>
           {email !== "" && !emailReg.test(email) ? (
             <ValidationView error={email !== "" && !emailReg.test(email)}>
-              <AntDesign name="exclamationcircleo" size={12} color="#ff6534" />
+              <AntDesign name="exclamationcircleo" size={12} color={lightTheme.accentColor} />
               <Error>{` 입력을 다시 한번 확인해주세요.`}</Error>
             </ValidationView>
           ) : (

--- a/screens/SignUp/SignUpName.tsx
+++ b/screens/SignUp/SignUpName.tsx
@@ -29,28 +29,28 @@ const Border = styled.View`
 `;
 
 const AskText = styled.Text`
-  font-family: "AppleSDGothicNeoB";
+  font-family: ${(props: any) => props.theme.koreanFontB};
   font-size: 20px;
   margin-top: 24px;
 `;
 
 const SubText = styled.Text`
-  font-family: "AppleSDGothicNeoR";
+  font-family: ${(props: any) => props.theme.koreanFontR};
   color: #a0a0a0;
   font-size: 13px;
   margin-top: 7px;
 `;
 
 const Input = styled.TextInput<{ error: boolean }>`
-  font-family: "AppleSDGothicNeoR";
+  font-family: ${(props: any) => props.theme.koreanFontR};
   border-bottom-width: 1px;
-  border-bottom-color: ${(props: any) => (props.error ? "#ff6534" : "#b3b3b3")};
+  border-bottom-color: ${(props: any) => (props.error ? props.theme.accentColor : "#b3b3b3")};
   margin-top: 47px;
   font-size: 18px;
 `;
 
 const Error = styled.Text`
-  font-family: "AppleSDGothicNeoR";
+  font-family: ${(props: any) => props.theme.koreanFontR};
   color: #e7564f;
   font-size: 12px;
 `;

--- a/screens/SignUp/SignUpPassword.tsx
+++ b/screens/SignUp/SignUpPassword.tsx
@@ -31,13 +31,13 @@ const Border = styled.View`
 `;
 
 const AskText = styled.Text`
-  font-family: "AppleSDGothicNeoB";
+  font-family: ${(props: any) => props.theme.koreanFontB};
   font-size: 20px;
   margin-top: 24px;
 `;
 
 const SubText = styled.Text`
-  font-family: "AppleSDGothicNeoR";
+  font-family: ${(props: any) => props.theme.koreanFontR};
   color: #a0a0a0;
   font-size: 13px;
   margin-top: 7px;
@@ -51,7 +51,7 @@ const Input = styled.TextInput`
 `;
 
 const Error = styled.Text`
-  font-family: "AppleSDGothicNeoR";
+  font-family: ${(props: any) => props.theme.koreanFontR};
   color: #e7564f;
   font-size: 12px;
 `;
@@ -69,7 +69,7 @@ const ValidationItem = styled.View`
 `;
 
 const ValidationText = styled.Text`
-  font-family: "AppleSDGothicNeoR";
+  font-family: ${(props: any) => props.theme.koreanFontR};
   color: #8e8e8e;
   font-size: 12px;
 `;

--- a/screens/SignUp/SignUpPassword.tsx
+++ b/screens/SignUp/SignUpPassword.tsx
@@ -4,6 +4,7 @@ import { TouchableOpacity, StatusBar, ScrollView, useWindowDimensions } from "re
 import styled from "styled-components/native";
 import { AntDesign, Entypo } from "@expo/vector-icons";
 import BottomButton from "../../components/BottomButton";
+import { lightTheme } from "../../theme";
 
 const Container = styled.View`
   flex: 1;
@@ -154,7 +155,7 @@ const SignUpPassword: React.FC<NativeStackScreenProps<any, "SignUpPassword">> = 
           />
           {password !== checkPassword && password !== "" && checkPassword !== "" ? (
             <ValidationView>
-              <AntDesign name="exclamationcircleo" size={12} color="#ff6534" />
+              <AntDesign name="exclamationcircleo" size={12} color={lightTheme.accentColor} />
               <Error>{` 입력을 다시 한번 확인해주세요.`}</Error>
             </ValidationView>
           ) : (

--- a/screens/SignUp/SignUpPhone.tsx
+++ b/screens/SignUp/SignUpPhone.tsx
@@ -29,13 +29,13 @@ const Border = styled.View`
 `;
 
 const AskText = styled.Text`
-  font-family: "AppleSDGothicNeoB";
+  font-family: ${(props: any) => props.theme.koreanFontB};
   font-size: 20px;
   margin-top: 24px;
 `;
 
 const SubText = styled.Text`
-  font-family: "AppleSDGothicNeoR";
+  font-family: ${(props: any) => props.theme.koreanFontR};
   color: #a0a0a0;
   font-size: 13px;
   margin-top: 7px;
@@ -43,7 +43,7 @@ const SubText = styled.Text`
 
 const Input = styled.TextInput`
   border-bottom-width: 1px;
-  border-bottom-color: ${(props: any) => (props.error ? "#E7564F" : "#b3b3b3")};
+  border-bottom-color: ${(props: any) => (props.error ? props.theme.accentColor : "#b3b3b3")};
   margin-top: 47px;
   font-size: 18px;
 `;
@@ -53,7 +53,7 @@ const ErrorView = styled.View`
 `;
 
 const Error = styled.Text`
-  font-family: "AppleSDGothicNeoR";
+  font-family: ${(props: any) => props.theme.koreanFontR};
   color: #e7564f;
   font-size: 12px;
   margin-top: 7px;
@@ -68,7 +68,7 @@ const FieldContentOptionLine = styled.View`
 const SkipButton = styled.TouchableOpacity``;
 
 const SkipText = styled.Text`
-  font-family: "AppleSDGothicNeoR";
+  font-family: ${(props: any) => props.theme.koreanFontR};
   font-size: 12px;
   color: #8e8e8e;
 `;

--- a/screens/SignUp/SignUpSex.tsx
+++ b/screens/SignUp/SignUpSex.tsx
@@ -30,13 +30,13 @@ const Border = styled.View`
 `;
 
 const AskText = styled.Text`
-  font-family: "AppleSDGothicNeoB";
+  font-family: ${(props: any) => props.theme.koreanFontB};
   font-size: 20px;
   margin-top: 24px;
 `;
 
 const SubText = styled.Text`
-  font-family: "AppleSDGothicNeoR";
+  font-family: ${(props: any) => props.theme.koreanFontR};
   color: #a0a0a0;
   font-size: 13px;
   margin-top: 7px;
@@ -59,7 +59,7 @@ const FieldContentOptionLine = styled.View`
 `;
 
 const FieldContentText = styled.Text`
-  font-family: "AppleSDGothicNeoR";
+  font-family: ${(props: any) => props.theme.koreanFontR};
   font-size: 18px;
   margin-right: 10px;
 `;
@@ -67,7 +67,7 @@ const FieldContentText = styled.Text`
 const SkipButton = styled.TouchableOpacity``;
 
 const SkipText = styled.Text`
-  font-family: "AppleSDGothicNeoR";
+  font-family: ${(props: any) => props.theme.koreanFontR};
   font-size: 12px;
   color: #8e8e8e;
 `;

--- a/screens/SignUp/SignUpSuccess.tsx
+++ b/screens/SignUp/SignUpSuccess.tsx
@@ -22,19 +22,19 @@ const Header = styled.View`
 
 const LineView = styled.View`
   height: 1.5px;
-  background-color: #aeaeae;
+  background-color: ${(props: any) => props.theme.infoColor};
 `;
 
 const HeaderTitle = styled.Text`
-  font-family: "Roboto-Medium";
+  font-family: ${(props: any) => props.theme.englishFontM};
   font-size: 40px;
   line-height: 43px;
 `;
 
 const HeaderText = styled.Text`
-  font-family: "AppleSDGothicNeoR";
+  font-family: ${(props: any) => props.theme.koreanFontR};
   font-size: 16px;
-  color: #aeaeae;
+  color: ${(props: any) => props.theme.infoColor};
   margin-top: 10px;
 `;
 
@@ -44,7 +44,7 @@ const Content = styled.View`
 `;
 
 const ContentText = styled.Text`
-  font-family: "AppleSDGothicNeoR";
+  font-family: ${(props: any) => props.theme.koreanFontR};
   font-size: 16px;
 `;
 
@@ -114,7 +114,7 @@ const SignUpSuccess: React.FC<NativeStackScreenProps<any, "SignUpSuccess">> = ({
         <LineView style={{ flex: 1, marginRight: 20, marginTop: 10 }} />
         <ContentText>{`각종 모임을 통해\n공동체를 누려보세요!`}</ContentText>
       </Content>
-      <BottomButton onPress={onSubmit} backgroundColor="#6B8BF7" title={"로그인하기"} />
+      <BottomButton onPress={onSubmit} title={"로그인하기"} />
     </Container>
   );
 };

--- a/screens/SignUp/SignUpTerms.tsx
+++ b/screens/SignUp/SignUpTerms.tsx
@@ -20,7 +20,7 @@ const Wrap = styled.View`
 `;
 
 const HeaderText = styled.Text`
-  font-family: "AppleSDGothicNeoM";
+  font-family: ${(props: any) => props.theme.koreanFontM};
   color: #2b2b2b;
   font-size: 16px;
   line-height: 21px;
@@ -36,15 +36,15 @@ const Item = styled.TouchableOpacity`
 `;
 
 const RedText = styled.Text`
-  font-family: "AppleSDGothicNeoM";
+  font-family: ${(props: any) => props.theme.koreanFontM};
   margin-right: 5px;
-  color: #ff6534;
+  color: ${(props: any) => props.theme.accentColor};
   font-size: 16px;
   line-height: 17px;
 `;
 
 const ItemText = styled.Text`
-  font-family: "AppleSDGothicNeoM";
+  font-family: ${(props: any) => props.theme.koreanFontM};
   color: #6f6f6f;
   font-size: 16px;
   line-height: 17px;

--- a/types/Club.ts
+++ b/types/Club.ts
@@ -11,7 +11,7 @@ export type ClubStackParamList = {
   ClubTopTabs: { clubData: Club };
   ClubHome: { clubData: Club };
   ClubFeed: { clubData: Club };
-  ClubFeedDetail: { clubData: Club; feedData: Feed[]; targetIndex: number };
+  ClubFeedDetail: { clubData: Club; targetIndex: number };
 
   ClubCreationStack: {};
   ClubCreationStepOne: { category: CategoryResponse };
@@ -70,25 +70,6 @@ export type ClubEditBasicsProps = NativeStackScreenProps<ClubStackParamList, "Cl
 export type ClubEditIntroductionProps = NativeStackScreenProps<ClubStackParamList, "ClubEditIntroduction">;
 export type ClubEditMembersProps = NativeStackScreenProps<ClubStackParamList, "ClubEditMembers">;
 export type ClubDeleteProps = NativeStackScreenProps<ClubStackParamList, "ClubDelete">;
-
-// ClubHome Param For Collapsed Scroll Animation
-export interface ClubHomeParamList {
-  scrollY: Animated.Value;
-  headerDiff: number;
-  offsetY?: number;
-  scheduleOffsetX?: number;
-  schedules?: RefinedSchedule[];
-  syncScrollOffset: (screenName: string) => void;
-  screenScrollRefs: any;
-}
-
-export interface ClubFeedParamList {
-  scrollY: Animated.Value;
-  offsetY?: number;
-  headerDiff: number;
-  syncScrollOffset: (screenName: string) => void;
-  screenScrollRefs: any;
-}
 
 // For TopTab Navigation
 export type TopTabParamList = {


### PR DESCRIPTION
1. 프로필 - 계정설정 화면 디자인 리뉴얼
2. 모임 홈 헤더 디자인 변경
3. 코드 내에 하드코딩된 폰트, 컬러 정보 theme 설정 파일로 일관화
4. 피드를 좋아요 설정, 해제할 때 유저리스트에 내 정보가 갱신되지 않던 버그 수정
5. club redux에서 1개의 클럽 정보만 보관하던 것을 dictionary 방식으로 변경